### PR TITLE
add stream provisioning status

### DIFF
--- a/pkg/apis/stream/v1alpha1/processor_lifecycle.go
+++ b/pkg/apis/stream/v1alpha1/processor_lifecycle.go
@@ -61,11 +61,11 @@ func (ps *ProcessorStatus) PropagateFunctionStatus(fs *buildv1alpha1.FunctionSta
 	}
 	switch {
 	case sc.Status == corev1.ConditionUnknown:
-		processorCondSet.Manage(fs).MarkUnknown(ProcessorConditionFunctionReady, sc.Reason, sc.Message)
+		processorCondSet.Manage(ps).MarkUnknown(ProcessorConditionFunctionReady, sc.Reason, sc.Message)
 	case sc.Status == corev1.ConditionTrue:
-		processorCondSet.Manage(fs).MarkTrue(ProcessorConditionFunctionReady)
+		processorCondSet.Manage(ps).MarkTrue(ProcessorConditionFunctionReady)
 	case sc.Status == corev1.ConditionFalse:
-		processorCondSet.Manage(fs).MarkFalse(ProcessorConditionFunctionReady, sc.Reason, sc.Message)
+		processorCondSet.Manage(ps).MarkFalse(ProcessorConditionFunctionReady, sc.Reason, sc.Message)
 	}
 }
 

--- a/pkg/apis/stream/v1alpha1/stream_lifecycle.go
+++ b/pkg/apis/stream/v1alpha1/stream_lifecycle.go
@@ -38,3 +38,11 @@ func (status *StreamStatus) GetCondition(t duckv1alpha1.ConditionType) *duckv1al
 func (status *StreamStatus) InitializeConditions() {
 	streamCondSet.Manage(status).InitializeConditions()
 }
+
+func (status *StreamStatus) MarkStreamProvisioned() {
+	streamCondSet.Manage(status).MarkTrue(StreamConditionReady)
+}
+
+func (status *StreamStatus) MarkStreamProvisionFailed(message string) {
+	streamCondSet.Manage(status).MarkFalse(StreamConditionReady, "ProvisionFailed", message)
+}

--- a/pkg/reconciler/v1alpha1/stream/stream.go
+++ b/pkg/reconciler/v1alpha1/stream/stream.go
@@ -144,8 +144,10 @@ func (c *Reconciler) reconcile(ctx context.Context, stream *streamv1alpha1.Strea
 	logger.Infof("Creating Stream %s with Provider %s", stream.Name, stream.Spec.Provider)
 	address, err := createStream(stream.Spec.Provider, stream.Name)
 	if err != nil {
+		stream.Status.MarkStreamProvisionFailed(err.Error())
 		return err
 	}
+	stream.Status.MarkStreamProvisioned()
 	stream.Status.Address = *address
 	stream.Status.ObservedGeneration = stream.Generation
 


### PR DESCRIPTION
also provide the proper target status when propagating function status for a processor