### PR TITLE
Stop reconciling resources that are being deleted

### DIFF
--- a/pkg/controllers/build/credentials_controller.go
+++ b/pkg/controllers/build/credentials_controller.go
@@ -73,6 +73,10 @@ func (r *CredentialReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 }
 
 func (r *CredentialReconciler) reconcile(ctx context.Context, log logr.Logger, serviceAccount *corev1.ServiceAccount, namespace string) (ctrl.Result, error) {
+	if serviceAccount != nil && serviceAccount.GetDeletionTimestamp() != nil {
+		return ctrl.Result{}, nil
+	}
+
 	secretNames := sets.NewString()
 	var secrets corev1.SecretList
 	if err := r.List(ctx, &secrets, client.InNamespace(namespace), MatchingLabels(buildv1alpha1.CredentialLabelKey)); err != nil {

--- a/pkg/controllers/core/deployer_controller.go
+++ b/pkg/controllers/core/deployer_controller.go
@@ -90,6 +90,10 @@ func (r *DeployerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 }
 
 func (r *DeployerReconciler) reconcile(ctx context.Context, log logr.Logger, deployer *corev1alpha1.Deployer) (ctrl.Result, error) {
+	if deployer.GetDeletionTimestamp() != nil {
+		return ctrl.Result{}, nil
+	}
+
 	// resolve build image
 	if err := r.reconcileBuildImage(ctx, log, deployer); err != nil {
 		if apierrs.IsNotFound(err) {

--- a/pkg/controllers/knative/adapter_controller.go
+++ b/pkg/controllers/knative/adapter_controller.go
@@ -88,6 +88,10 @@ func (r *AdapterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 }
 
 func (r *AdapterReconciler) reconcile(ctx context.Context, log logr.Logger, adapter *knativev1alpha1.Adapter) (ctrl.Result, error) {
+	if adapter.GetDeletionTimestamp() != nil {
+		return ctrl.Result{}, nil
+	}
+
 	// resolve build image
 	if err := r.reconcileBuildImage(ctx, log, adapter); err != nil {
 		if apierrs.IsNotFound(err) {

--- a/pkg/controllers/knative/deployer_controller.go
+++ b/pkg/controllers/knative/deployer_controller.go
@@ -88,6 +88,10 @@ func (r *DeployerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 }
 
 func (r *DeployerReconciler) reconcile(ctx context.Context, log logr.Logger, deployer *knativev1alpha1.Deployer) (ctrl.Result, error) {
+	if deployer.GetDeletionTimestamp() != nil {
+		return ctrl.Result{}, nil
+	}
+
 	// resolve build image
 	if err := r.reconcileBuildImage(ctx, log, deployer); err != nil {
 		if apierrs.IsNotFound(err) {

--- a/pkg/controllers/streaming/provider_controller.go
+++ b/pkg/controllers/streaming/provider_controller.go
@@ -86,6 +86,9 @@ func (r *ProviderReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 }
 
 func (r *ProviderReconciler) reconcile(ctx context.Context, log logr.Logger, provider *streamingv1alpha1.Provider) (ctrl.Result, error) {
+	if provider.GetDeletionTimestamp() != nil {
+		return ctrl.Result{}, nil
+	}
 
 	// Lookup and track configMap to know which images to use
 	cm := corev1.ConfigMap{}


### PR DESCRIPTION
A resource may exist while it is being deleted (finalizers). We should
not continue to reconcile the resource and assume that it is going away
very shortly.