### PR TITLE
Fix leader election id, used for ConfigMap name.

### DIFF
--- a/cmd/managers/build/main.go
+++ b/cmd/managers/build/main.go
@@ -58,6 +58,7 @@ func main() {
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
 		LeaderElection:     enableLeaderElection,
+		LeaderElectionID:   "controller-leader-election-helper-build",
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/cmd/managers/core/main.go
+++ b/cmd/managers/core/main.go
@@ -62,6 +62,7 @@ func main() {
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
 		LeaderElection:     enableLeaderElection,
+		LeaderElectionID:   "controller-leader-election-helper-core",
 		SyncPeriod:         &syncPeriod,
 	})
 	if err != nil {

--- a/cmd/managers/knative/main.go
+++ b/cmd/managers/knative/main.go
@@ -64,6 +64,7 @@ func main() {
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
 		LeaderElection:     enableLeaderElection,
+		LeaderElectionID:   "controller-leader-election-helper-knative",
 		SyncPeriod:         &syncPeriod,
 	})
 	if err != nil {

--- a/cmd/managers/streaming/main.go
+++ b/cmd/managers/streaming/main.go
@@ -67,6 +67,7 @@ func main() {
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
 		LeaderElection:     enableLeaderElection,
+		LeaderElectionID:   "controller-leader-election-helper-streaming",
 		SyncPeriod:         &syncPeriod,
 	})
 	if err != nil {


### PR DESCRIPTION
Previously, all 4 managers were competing for the same map, and a
blocked manager appears stuck.