### PR TITLE
Use namespace in Gateway address.

### DIFF
--- a/pkg/controllers/streaming/kafkaprovider_controller.go
+++ b/pkg/controllers/streaming/kafkaprovider_controller.go
@@ -444,7 +444,7 @@ func (r *KafkaProviderReconciler) constructProvisionerDeploymentForKafkaProvider
 	labels := r.constructProvisionerLabelsForKafkaProvider(kafkaProvider)
 
 	env := []corev1.EnvVar{
-		{Name: "GATEWAY", Value: kafkaProvider.Status.LiiklusServiceName + ":6565"}, // TODO get port numnber from svc lookup
+		{Name: "GATEWAY", Value: fmt.Sprintf("%s.%s:6565", kafkaProvider.Status.LiiklusServiceName, kafkaProvider.Namespace)}, // TODO get port numnber from svc lookup
 		{Name: "BROKER", Value: kafkaProvider.Spec.BootstrapServers},
 	}
 	deployment := &appsv1.Deployment{


### PR DESCRIPTION
When addressed from outside the same namespace (eg from riff-system),
the gateway needs a fully resolvable DNS name.