### PR TITLE
Name images so that the manifest scanner can find them

### DIFF
--- a/config/riff-streaming.yaml
+++ b/config/riff-streaming.yaml
@@ -643,8 +643,8 @@ subjects:
 ---
 apiVersion: v1
 data:
-  liiklus: bsideup/liiklus:0.9.0
-  provisioner: gcr.io/projectriff/kafka-provisioner/provisioner-97dd22e72aed3201586a126a023b55db@sha256:fca4914e7e86a54c7093bd778df013a69a700123f65a831f7331158f9478dfda
+  liiklusImage: bsideup/liiklus:0.9.0
+  provisionerImage: gcr.io/projectriff/kafka-provisioner/provisioner-97dd22e72aed3201586a126a023b55db@sha256:fca4914e7e86a54c7093bd778df013a69a700123f65a831f7331158f9478dfda
 kind: ConfigMap
 metadata:
   labels:
@@ -654,7 +654,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  processor: projectriff/streaming-processor
+  processorImage: projectriff/streaming-processor
 kind: ConfigMap
 metadata:
   labels:

--- a/config/streaming/config/bases/kafka-provider.yaml
+++ b/config/streaming/config/bases/kafka-provider.yaml
@@ -3,6 +3,6 @@ kind: ConfigMap
 metadata:
   name: kafka-provider
 data:
-  liiklus: bsideup/liiklus:0.9.0
-  provisioner: gcr.io/projectriff/kafka-provisioner/provisioner-97dd22e72aed3201586a126a023b55db@sha256:fca4914e7e86a54c7093bd778df013a69a700123f65a831f7331158f9478dfda
+  liiklusImage: bsideup/liiklus:0.9.0
+  provisionerImage: gcr.io/projectriff/kafka-provisioner/provisioner-97dd22e72aed3201586a126a023b55db@sha256:fca4914e7e86a54c7093bd778df013a69a700123f65a831f7331158f9478dfda
 

--- a/config/streaming/config/bases/processor.yaml
+++ b/config/streaming/config/bases/processor.yaml
@@ -3,4 +3,4 @@ kind: ConfigMap
 metadata:
   name: processor
 data:
-  processor: projectriff/streaming-processor
+  processorImage: projectriff/streaming-processor

--- a/pkg/controllers/streaming/config.go
+++ b/pkg/controllers/streaming/config.go
@@ -20,9 +20,9 @@ const (
 	kustomizePrefix = "riff-streaming" // kustomize adds this prefix to all our resource names
 
 	kafkaProviderImages = kustomizePrefix + "-kafka-provider" // contains image names for the kafka provider
-	liiklusImageKey     = "liiklus"
-	provisionerImageKey = "provisioner"
+	liiklusImageKey     = "liiklusImage"
+	provisionerImageKey = "provisionerImage"
 
 	processorImages   = kustomizePrefix + "-processor" // contains image names for the streaming processor
-	processorImageKey = "processor"
+	processorImageKey = "processorImage"
 )


### PR DESCRIPTION
The https://github.com/projectriff/k8s-manifest-scanner looks for yaml
keys that are `image` or end with `Image`. Renaming the configmap image
keys to align with this convention.

The new strings are also much more findable in the codebase.