### PR TITLE
Avoid child name collisions and deadlocked creates in streaming runtime

### DIFF
--- a/pkg/apis/streaming/v1alpha1/kafkaprovider_lifecycle.go
+++ b/pkg/apis/streaming/v1alpha1/kafkaprovider_lifecycle.go
@@ -58,11 +58,6 @@ func (ps *KafkaProviderStatus) InitializeConditions() {
 	providerCondSet.Manage(ps).InitializeConditions()
 }
 
-func (ps *KafkaProviderStatus) MarkLiiklusDeploymentNotOwned() {
-	providerCondSet.Manage(ps).MarkFalse(KafkaProviderConditionLiiklusDeploymentReady, "NotOwned",
-		"There is an existing Deployment %q that we do not own.", ps.LiiklusDeploymentName)
-}
-
 func (ps *KafkaProviderStatus) PropagateLiiklusDeploymentStatus(cds *appsv1.DeploymentStatus) {
 	var available, progressing *appsv1.DeploymentCondition
 	for i := range cds.Conditions {
@@ -91,19 +86,9 @@ func (ps *KafkaProviderStatus) PropagateLiiklusDeploymentStatus(cds *appsv1.Depl
 	}
 }
 
-func (ps *KafkaProviderStatus) MarkLiiklusServiceNotOwned() {
-	providerCondSet.Manage(ps).MarkFalse(KafkaProviderConditionLiiklusServiceReady, "NotOwned",
-		"There is an existing Service %q that we do not own.", ps.LiiklusServiceName)
-}
-
 func (ps *KafkaProviderStatus) PropagateLiiklusServiceStatus(ss *corev1.ServiceStatus) {
 	// services don't have meaningful status
 	providerCondSet.Manage(ps).MarkTrue(KafkaProviderConditionLiiklusServiceReady)
-}
-
-func (ps *KafkaProviderStatus) MarkProvisionerDeploymentNotOwned() {
-	providerCondSet.Manage(ps).MarkFalse(KafkaProviderConditionProvisionerDeploymentReady, "NotOwned",
-		"There is an existing Deployment %q that we do not own.", ps.ProvisionerDeploymentName)
 }
 
 func (ps *KafkaProviderStatus) PropagateProvisionerDeploymentStatus(cds *appsv1.DeploymentStatus) {
@@ -132,11 +117,6 @@ func (ps *KafkaProviderStatus) PropagateProvisionerDeploymentStatus(cds *appsv1.
 	case available.Status == corev1.ConditionFalse:
 		providerCondSet.Manage(ps).MarkFalse(KafkaProviderConditionProvisionerDeploymentReady, available.Reason, available.Message)
 	}
-}
-
-func (ps *KafkaProviderStatus) MarkProvisionerServiceNotOwned() {
-	providerCondSet.Manage(ps).MarkFalse(KafkaProviderConditionProvisionerServiceReady, "NotOwned",
-		"There is an existing Service %q that we do not own.", ps.ProvisionerServiceName)
 }
 
 func (ps *KafkaProviderStatus) PropagateProvisionerServiceStatus(ss *corev1.ServiceStatus) {

--- a/pkg/apis/streaming/v1alpha1/processor_lifecycle.go
+++ b/pkg/apis/streaming/v1alpha1/processor_lifecycle.go
@@ -75,16 +75,6 @@ func (ps *ProcessorStatus) PropagateFunctionStatus(fs *buildv1alpha1.FunctionSta
 	}
 }
 
-func (ps *ProcessorStatus) MarkDeploymentNotOwned() {
-	processorCondSet.Manage(ps).MarkFalse(ProcessorConditionDeploymentReady, "NotOwned",
-		"There is an existing Deployment %q that we do not own.", ps.DeploymentName)
-}
-
-func (ps *ProcessorStatus) MarkScaledObjectNotOwned() {
-	processorCondSet.Manage(ps).MarkFalse(ProcessorConditionScaledObjectReady, "NotOwned",
-		"There is an existing ScaledObject %q that we do not own.", ps.ScaledObjectName)
-}
-
 func (ps *ProcessorStatus) PropagateDeploymentStatus(ds *appsv1.DeploymentStatus) {
 	var available, progressing *appsv1.DeploymentCondition
 	for i := range ds.Conditions {


### PR DESCRIPTION
Avoids two distinct issues:

1. name collisions of child resources
2. deadlocked create when status update fails after creating fixed name
   child resource

The name collision is common if a knative and core deployer of the same
name is created. The create deadlock is rare, but has caused a number of
FATS failures.

These issues are resolved by using generated names rather than fixed
names, and the reconciler no longer depends on the child resource name
set in the status. The reconciler will instead list all child resources
with the target resource as the owner.

The listing should return with zero or one item. If zero, a new resource
is created, if one, that resources is reconciled. If there happens to
be more than one item, they are all deleted and then a new clean
resource is created.

Resolves #138