### PR TITLE
Use fixed version of kustomize.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,9 +31,8 @@ jobs:
         echo "##[add-path]/usr/local/kubebuilder/bin"
     - name: Install kustomize
       run: |
-        opsys=`go env GOOS`
-        curl -O -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.2.2/kustomize_kustomize.v3.2.2_${opsys}_amd64
-        mv kustomize_*_${opsys}_amd64 kustomize
+        curl -O -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.2.3/kustomize_kustomize.v3.2.3_linux_amd64
+        mv kustomize_*_linux_amd64 kustomize
         chmod u+x kustomize
         sudo mv kustomize /usr/local/bin/
     - name: Build & Test
@@ -69,13 +68,8 @@ jobs:
           echo "##[add-path]/usr/local/kubebuilder/bin"
       - name: Install kustomize
         run: |
-          opsys=`go env GOOS`
-          curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases/latest |\
-            grep browser_download |\
-            grep $opsys |\
-            cut -d '"' -f 4 |\
-            xargs curl -O -L
-          mv kustomize_*_${opsys}_amd64 kustomize
+          curl -O -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.2.3/kustomize_kustomize.v3.2.3_linux_amd64
+          mv kustomize_*_linux_amd64 kustomize
           chmod u+x kustomize
           sudo mv kustomize /usr/local/bin/
       - name: Install ko


### PR DESCRIPTION
This is what I used in http-gateway. Seems like overkill
to be "too-smart", in particular now that kustomize will
be available as part of kubectl.