### PR TITLE
Rename liiklus to gateway

### DIFF
--- a/config/riff-streaming.yaml
+++ b/config/riff-streaming.yaml
@@ -99,9 +99,9 @@ spec:
                 - type
                 type: object
               type: array
-            liiklusDeploymentName:
+            gatewayDeploymentName:
               type: string
-            liiklusServiceName:
+            gatewayServiceName:
               type: string
             observedGeneration:
               description: ObservedGeneration is the 'Generation' of the Service that
@@ -112,11 +112,6 @@ spec:
               type: string
             provisionerServiceName:
               type: string
-          required:
-          - liiklusDeploymentName
-          - liiklusServiceName
-          - provisionerDeploymentName
-          - provisionerServiceName
           type: object
       type: object
   version: v1alpha1
@@ -4777,7 +4772,7 @@ subjects:
 ---
 apiVersion: v1
 data:
-  liiklusImage: bsideup/liiklus:0.9.0
+  gatewayImage: bsideup/liiklus:0.9.0
   provisionerImage: gcr.io/projectriff/kafka-provisioner/provisioner-97dd22e72aed3201586a126a023b55db@sha256:5c21bf354fe3804b4acbc8326f7a7820e4a0cbd427af9832fd87d264a611a8de
 kind: ConfigMap
 metadata:

--- a/config/streaming/config/bases/kafka-provider.yaml
+++ b/config/streaming/config/bases/kafka-provider.yaml
@@ -3,6 +3,6 @@ kind: ConfigMap
 metadata:
   name: kafka-provider
 data:
-  liiklusImage: bsideup/liiklus:0.9.0
+  gatewayImage: bsideup/liiklus:0.9.0
   provisionerImage: gcr.io/projectriff/kafka-provisioner/provisioner-97dd22e72aed3201586a126a023b55db@sha256:5c21bf354fe3804b4acbc8326f7a7820e4a0cbd427af9832fd87d264a611a8de
 

--- a/config/streaming/crd/bases/streaming.projectriff.io_kafkaproviders.yaml
+++ b/config/streaming/crd/bases/streaming.projectriff.io_kafkaproviders.yaml
@@ -92,9 +92,9 @@ spec:
                 - type
                 type: object
               type: array
-            liiklusDeploymentName:
+            gatewayDeploymentName:
               type: string
-            liiklusServiceName:
+            gatewayServiceName:
               type: string
             observedGeneration:
               description: ObservedGeneration is the 'Generation' of the Service that
@@ -105,11 +105,6 @@ spec:
               type: string
             provisionerServiceName:
               type: string
-          required:
-          - liiklusDeploymentName
-          - liiklusServiceName
-          - provisionerDeploymentName
-          - provisionerServiceName
           type: object
       type: object
   version: v1alpha1

--- a/pkg/apis/streaming/v1alpha1/kafkaprovider_lifecycle.go
+++ b/pkg/apis/streaming/v1alpha1/kafkaprovider_lifecycle.go
@@ -25,15 +25,15 @@ import (
 
 const (
 	KafkaProviderConditionReady                                         = apis.ConditionReady
-	KafkaProviderConditionLiiklusDeploymentReady     apis.ConditionType = "LiiklusDeploymentReady"
-	KafkaProviderConditionLiiklusServiceReady        apis.ConditionType = "LiiklusServiceReady"
+	KafkaProviderConditionGatewayDeploymentReady     apis.ConditionType = "GatewayDeploymentReady"
+	KafkaProviderConditionGatewayServiceReady        apis.ConditionType = "GatewayServiceReady"
 	KafkaProviderConditionProvisionerDeploymentReady apis.ConditionType = "ProvisionerDeploymentReady"
 	KafkaProviderConditionProvisionerServiceReady    apis.ConditionType = "ProvisionerServiceReady"
 )
 
 var providerCondSet = apis.NewLivingConditionSet(
-	KafkaProviderConditionLiiklusDeploymentReady,
-	KafkaProviderConditionLiiklusServiceReady,
+	KafkaProviderConditionGatewayDeploymentReady,
+	KafkaProviderConditionGatewayServiceReady,
 	KafkaProviderConditionProvisionerDeploymentReady,
 	KafkaProviderConditionProvisionerServiceReady,
 )
@@ -58,7 +58,7 @@ func (ps *KafkaProviderStatus) InitializeConditions() {
 	providerCondSet.Manage(ps).InitializeConditions()
 }
 
-func (ps *KafkaProviderStatus) PropagateLiiklusDeploymentStatus(cds *appsv1.DeploymentStatus) {
+func (ps *KafkaProviderStatus) PropagateGatewayDeploymentStatus(cds *appsv1.DeploymentStatus) {
 	var available, progressing *appsv1.DeploymentCondition
 	for i := range cds.Conditions {
 		switch cds.Conditions[i].Type {
@@ -73,22 +73,22 @@ func (ps *KafkaProviderStatus) PropagateLiiklusDeploymentStatus(cds *appsv1.Depl
 	}
 	if progressing.Status == corev1.ConditionTrue && available.Status == corev1.ConditionFalse {
 		// DeploymentAvailable is False while progressing, avoid reporting KafkaProviderConditionReady as False
-		providerCondSet.Manage(ps).MarkUnknown(KafkaProviderConditionLiiklusDeploymentReady, progressing.Reason, progressing.Message)
+		providerCondSet.Manage(ps).MarkUnknown(KafkaProviderConditionGatewayDeploymentReady, progressing.Reason, progressing.Message)
 		return
 	}
 	switch {
 	case available.Status == corev1.ConditionUnknown:
-		providerCondSet.Manage(ps).MarkUnknown(KafkaProviderConditionLiiklusDeploymentReady, available.Reason, available.Message)
+		providerCondSet.Manage(ps).MarkUnknown(KafkaProviderConditionGatewayDeploymentReady, available.Reason, available.Message)
 	case available.Status == corev1.ConditionTrue:
-		providerCondSet.Manage(ps).MarkTrue(KafkaProviderConditionLiiklusDeploymentReady)
+		providerCondSet.Manage(ps).MarkTrue(KafkaProviderConditionGatewayDeploymentReady)
 	case available.Status == corev1.ConditionFalse:
-		providerCondSet.Manage(ps).MarkFalse(KafkaProviderConditionLiiklusDeploymentReady, available.Reason, available.Message)
+		providerCondSet.Manage(ps).MarkFalse(KafkaProviderConditionGatewayDeploymentReady, available.Reason, available.Message)
 	}
 }
 
-func (ps *KafkaProviderStatus) PropagateLiiklusServiceStatus(ss *corev1.ServiceStatus) {
+func (ps *KafkaProviderStatus) PropagateGatewayServiceStatus(ss *corev1.ServiceStatus) {
 	// services don't have meaningful status
-	providerCondSet.Manage(ps).MarkTrue(KafkaProviderConditionLiiklusServiceReady)
+	providerCondSet.Manage(ps).MarkTrue(KafkaProviderConditionGatewayServiceReady)
 }
 
 func (ps *KafkaProviderStatus) PropagateProvisionerDeploymentStatus(cds *appsv1.DeploymentStatus) {

--- a/pkg/apis/streaming/v1alpha1/kafkaprovider_types.go
+++ b/pkg/apis/streaming/v1alpha1/kafkaprovider_types.go
@@ -28,7 +28,7 @@ import (
 
 var (
 	KafkaProviderLabelKey            = GroupVersion.Group + "/kafka-provider"             // Identifies all resources originating from a provider
-	KafkaProviderLiiklusLabelKey     = GroupVersion.Group + "/kafka-provider-liiklus"     // Used as a selector
+	KafkaProviderGatewayLabelKey     = GroupVersion.Group + "/kafka-provider-gateway"     // Used as a selector
 	KafkaProviderProvisionerLabelKey = GroupVersion.Group + "/kafka-provider-provisioner" // Used as a selector
 	KafkaProvisioner                 = "kafka-provisioner"
 )
@@ -56,10 +56,10 @@ type KafkaProviderStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	apis.Status               `json:",inline"`
-	LiiklusDeploymentName     string `json:"liiklusDeploymentName"`
-	LiiklusServiceName        string `json:"liiklusServiceName"`
-	ProvisionerDeploymentName string `json:"provisionerDeploymentName"`
-	ProvisionerServiceName    string `json:"provisionerServiceName"`
+	GatewayDeploymentName     string `json:"gatewayDeploymentName,omitempty"`
+	GatewayServiceName        string `json:"gatewayServiceName,omitempty"`
+	ProvisionerDeploymentName string `json:"provisionerDeploymentName,omitempty"`
+	ProvisionerServiceName    string `json:"provisionerServiceName,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/controllers/streaming/config.go
+++ b/pkg/controllers/streaming/config.go
@@ -20,7 +20,7 @@ const (
 	kustomizePrefix = "riff-streaming" // kustomize adds this prefix to all our resource names
 
 	kafkaProviderImages = kustomizePrefix + "-kafka-provider" // contains image names for the kafka provider
-	liiklusImageKey     = "liiklusImage"
+	gatewayImageKey     = "gatewayImage"
 	provisionerImageKey = "provisionerImage"
 
 	processorImages   = kustomizePrefix + "-processor" // contains image names for the streaming processor


### PR DESCRIPTION
Use the component's role in the system as its name instead of the
implementation technology. Particularly as part of the public API, we
should favor stable names that won't need to change even if we adopt a
different technology, or that tech is rebranded.