### PR TITLE
Require a Processor's Streams be ready

### DIFF
--- a/pkg/apis/streaming/v1alpha1/processor_lifecycle.go
+++ b/pkg/apis/streaming/v1alpha1/processor_lifecycle.go
@@ -28,11 +28,13 @@ const (
 	ProcessorConditionReady = apis.ConditionReady
 	// TODO add aggregated streams ready status
 	ProcessorConditionFunctionReady     apis.ConditionType = "FunctionReady"
+	ProcessorConditionStreamsReady      apis.ConditionType = "StreamsReady"
 	ProcessorConditionDeploymentReady   apis.ConditionType = "DeploymentReady"
 	ProcessorConditionScaledObjectReady apis.ConditionType = "ScaledObjectReady"
 )
 
 var processorCondSet = apis.NewLivingConditionSet(
+	ProcessorConditionStreamsReady,
 	ProcessorConditionDeploymentReady,
 	ProcessorConditionScaledObjectReady,
 )
@@ -55,6 +57,14 @@ func (ps *ProcessorStatus) GetCondition(t apis.ConditionType) *apis.Condition {
 
 func (ps *ProcessorStatus) InitializeConditions() {
 	processorCondSet.Manage(ps).InitializeConditions()
+}
+
+func (ps *ProcessorStatus) MarkStreamsReady() {
+	processorCondSet.Manage(ps).MarkTrue(ProcessorConditionStreamsReady)
+}
+
+func (ps *ProcessorStatus) MarkStreamsNotReady(message string) {
+	processorCondSet.Manage(ps).MarkFalse(ProcessorConditionStreamsReady, "StreamNotReady", message)
 }
 
 func (ps *ProcessorStatus) PropagateDeploymentStatus(ds *appsv1.DeploymentStatus) {

--- a/pkg/controllers/streaming/processor_controller.go
+++ b/pkg/controllers/streaming/processor_controller.go
@@ -416,7 +416,7 @@ func (r *ProcessorReconciler) reconcileProcessorDeployment(ctx context.Context, 
 func (r *ProcessorReconciler) constructDeploymentForProcessor(processor *streamingv1alpha1.Processor, processorImg string) (*appsv1.Deployment, error) {
 	labels := r.constructLabelsForProcessor(processor)
 
-	one := int32(1)
+	zero := int32(0)
 	environmentVariables, err := r.computeEnvironmentVariables(processor)
 	if err != nil {
 		return nil, err
@@ -444,7 +444,7 @@ func (r *ProcessorReconciler) constructDeploymentForProcessor(processor *streami
 			Labels:       labels,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: &one,
+			Replicas: &zero,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					streamingv1alpha1.ProcessorLabelKey: processor.Name,

--- a/pkg/controllers/streaming/processor_controller.go
+++ b/pkg/controllers/streaming/processor_controller.go
@@ -199,9 +199,12 @@ func (r *ProcessorReconciler) reconcile(ctx context.Context, logger logr.Logger,
 
 	processor.Status.MarkStreamsReady()
 	for _, stream := range append(inputStreams, outputStreams...) {
-		if !stream.Status.IsReady() {
-			ready := stream.Status.GetCondition(stream.Status.GetReadyConditionType())
-			processor.Status.MarkStreamsNotReady(fmt.Sprintf("Stream %s is not ready: %s", stream.Name, ready.Message))
+		ready := stream.Status.GetCondition(stream.Status.GetReadyConditionType())
+		if ready == nil {
+			ready = &apis.Condition{Message: "stream has no ready condition"}
+		}
+		if !ready.IsTrue() {
+			processor.Status.MarkStreamsNotReady(fmt.Sprintf("stream %s is not ready: %s", stream.Name, ready.Message))
 			break
 		}
 	}


### PR DESCRIPTION
Sets a Processer's max replicas to zero when any input or output Stream
is not ready. Adds a new status condition StreamsReady which aggregates
all input and output stream ready conditions. The StreamsReady condition
itself is aggregated to the Processor's Ready condition.

Resolves #117
Alternative to #170