### PR TITLE
Update to use cert-manager v0.11.0

### DIFF
--- a/.github/workflows/cleanup-runtime.sh
+++ b/.github/workflows/cleanup-runtime.sh
@@ -37,7 +37,10 @@ elif [ $RUNTIME = "knative" ]; then
 fi
 
 echo "Cleanup Cert Manager"
-helm delete --purge cert-manager
+#TODO: change back to Helm after charts are updated with cert-manager v0.11.0
+#helm delete --purge cert-manager
+kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v0.11.0/cert-manager.yaml
+#TODO: ^^^
 kubectl delete customresourcedefinitions.apiextensions.k8s.io -l app.kubernetes.io/managed-by=Tiller,app.kubernetes.io/instance=cert-manager 
 
 echo "Remove Helm"

--- a/.github/workflows/install-runtime.sh
+++ b/.github/workflows/install-runtime.sh
@@ -30,7 +30,14 @@ sleep 5
 wait_pod_selector_ready app=cert-manager cert-manager
 wait_pod_selector_ready app=webhook cert-manager
 
-source $FATS_DIR/macros/no-resource-requests.sh
+#TODO: change back to FATS after it is with cert-manager v0.11.0
+# source $FATS_DIR/macros/no-resource-requests.sh
+if [ $(kubectl get nodes -oname | wc -l) = "1" ]; then
+  echo "Eliminate pod resource requests"
+  fats_retry kubectl apply -f https://storage.googleapis.com/projectriff/no-resource-requests-webhook/no-resource-requests-webhook-20191121210956-521ae2a8c3323540.yaml
+  wait_pod_selector_ready app=webhook no-resource-requests
+fi
+#TODO: ^^^
 
 echo "Installing kpack"
 fats_retry kubectl apply -f https://storage.googleapis.com/projectriff/internal/kpack/kpack-0.0.5-snapshot-5a4e635d.yaml

--- a/.github/workflows/install-runtime.sh
+++ b/.github/workflows/install-runtime.sh
@@ -22,7 +22,10 @@ helm repo add projectriff https://projectriff.storage.googleapis.com/charts/rele
 helm repo update
 
 echo "Installing Cert Manager"
-helm install projectriff/cert-manager --name cert-manager --devel --wait
+#TODO: change back to Helm after charts are updated with cert-manager v0.11.0
+#helm install projectriff/cert-manager --name cert-manager --devel --wait
+kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v0.11.0/cert-manager.yaml
+#TODO: ^^^
 sleep 5
 wait_pod_selector_ready app=cert-manager cert-manager
 wait_pod_selector_ready app=webhook cert-manager

--- a/config/build/certmanager/certificate.yaml
+++ b/config/build/certmanager/certificate.yaml
@@ -1,6 +1,6 @@
 # The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -8,7 +8,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
@@ -17,6 +17,7 @@ spec:
   # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
   commonName: $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
   dnsNames:
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
   issuerRef:
     kind: Issuer

--- a/config/build/certmanager/kustomizeconfig.yaml
+++ b/config/build/certmanager/kustomizeconfig.yaml
@@ -1,16 +1,16 @@
 # This configuration is for teaching kustomize how to update name ref and var substitution 
 nameReference:
 - kind: Issuer
-  group: certmanager.k8s.io
+  group: cert-manager.io
   fieldSpecs:
   - kind: Certificate
-    group: certmanager.k8s.io
+    group: cert-manager.io
     path: spec/issuerRef/name
 
 varReference:
 - kind: Certificate
-  group: certmanager.k8s.io
+  group: cert-manager.io
   path: spec/commonName
 - kind: Certificate
-  group: certmanager.k8s.io
+  group: cert-manager.io
   path: spec/dnsNames

--- a/config/build/crd/patches/cainjection_in_applications.yaml
+++ b/config/build/crd/patches/cainjection_in_applications.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
   name: applications.build.projectriff.io

--- a/config/build/crd/patches/cainjection_in_containers.yaml
+++ b/config/build/crd/patches/cainjection_in_containers.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
   name: containers.build.projectriff.io

--- a/config/build/crd/patches/cainjection_in_functions.yaml
+++ b/config/build/crd/patches/cainjection_in_functions.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
   name: functions.build.projectriff.io

--- a/config/build/default/kustomization.yaml
+++ b/config/build/default/kustomization.yaml
@@ -57,16 +57,16 @@ vars:
 - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
   objref:
     kind: Certificate
-    group: certmanager.k8s.io
-    version: v1alpha1
+    group: cert-manager.io
+    version: v1alpha2
     name: serving-cert # this name should match the one in certificate.yaml
   fieldref:
     fieldpath: metadata.namespace
 - name: CERTIFICATE_NAME
   objref:
     kind: Certificate
-    group: certmanager.k8s.io
-    version: v1alpha1
+    group: cert-manager.io
+    version: v1alpha2
     name: serving-cert # this name should match the one in certificate.yaml
 - name: SERVICE_NAMESPACE # namespace of the service
   objref:

--- a/config/build/default/webhookcainjection_patch.yaml
+++ b/config/build/default/webhookcainjection_patch.yaml
@@ -5,11 +5,11 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)

--- a/config/core/certmanager/certificate.yaml
+++ b/config/core/certmanager/certificate.yaml
@@ -1,6 +1,6 @@
 # The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -8,7 +8,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
@@ -17,6 +17,7 @@ spec:
   # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
   commonName: $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
   dnsNames:
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
   issuerRef:
     kind: Issuer

--- a/config/core/certmanager/kustomizeconfig.yaml
+++ b/config/core/certmanager/kustomizeconfig.yaml
@@ -1,16 +1,16 @@
 # This configuration is for teaching kustomize how to update name ref and var substitution 
 nameReference:
 - kind: Issuer
-  group: certmanager.k8s.io
+  group: cert-manager.io
   fieldSpecs:
   - kind: Certificate
-    group: certmanager.k8s.io
+    group: cert-manager.io
     path: spec/issuerRef/name
 
 varReference:
 - kind: Certificate
-  group: certmanager.k8s.io
+  group: cert-manager.io
   path: spec/commonName
 - kind: Certificate
-  group: certmanager.k8s.io
+  group: cert-manager.io
   path: spec/dnsNames

--- a/config/core/crd/patches/cainjection_in_deployers.yaml
+++ b/config/core/crd/patches/cainjection_in_deployers.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
   name: deployers.core.projectriff.io

--- a/config/core/default/kustomization.yaml
+++ b/config/core/default/kustomization.yaml
@@ -47,16 +47,16 @@ vars:
 - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
   objref:
     kind: Certificate
-    group: certmanager.k8s.io
-    version: v1alpha1
+    group: cert-manager.io
+    version: v1alpha2
     name: serving-cert # this name should match the one in certificate.yaml
   fieldref:
     fieldpath: metadata.namespace
 - name: CERTIFICATE_NAME
   objref:
     kind: Certificate
-    group: certmanager.k8s.io
-    version: v1alpha1
+    group: cert-manager.io
+    version: v1alpha2
     name: serving-cert # this name should match the one in certificate.yaml
 - name: SERVICE_NAMESPACE # namespace of the service
   objref:

--- a/config/core/default/webhookcainjection_patch.yaml
+++ b/config/core/default/webhookcainjection_patch.yaml
@@ -5,11 +5,11 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)

--- a/config/knative/certmanager/certificate.yaml
+++ b/config/knative/certmanager/certificate.yaml
@@ -1,6 +1,6 @@
 # The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -8,7 +8,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
@@ -17,6 +17,7 @@ spec:
   # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
   commonName: $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
   dnsNames:
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
   issuerRef:
     kind: Issuer

--- a/config/knative/certmanager/kustomizeconfig.yaml
+++ b/config/knative/certmanager/kustomizeconfig.yaml
@@ -1,16 +1,16 @@
 # This configuration is for teaching kustomize how to update name ref and var substitution 
 nameReference:
 - kind: Issuer
-  group: certmanager.k8s.io
+  group: cert-manager.io
   fieldSpecs:
   - kind: Certificate
-    group: certmanager.k8s.io
+    group: cert-manager.io
     path: spec/issuerRef/name
 
 varReference:
 - kind: Certificate
-  group: certmanager.k8s.io
+  group: cert-manager.io
   path: spec/commonName
 - kind: Certificate
-  group: certmanager.k8s.io
+  group: cert-manager.io
   path: spec/dnsNames

--- a/config/knative/crd/patches/cainjection_in_adapters.yaml
+++ b/config/knative/crd/patches/cainjection_in_adapters.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
   name: adapters.knative.projectriff.io

--- a/config/knative/crd/patches/cainjection_in_deployers.yaml
+++ b/config/knative/crd/patches/cainjection_in_deployers.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
   name: deployers.knative.projectriff.io

--- a/config/knative/default/kustomization.yaml
+++ b/config/knative/default/kustomization.yaml
@@ -47,16 +47,16 @@ vars:
 - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
   objref:
     kind: Certificate
-    group: certmanager.k8s.io
-    version: v1alpha1
+    group: cert-manager.io
+    version: v1alpha2
     name: serving-cert # this name should match the one in certificate.yaml
   fieldref:
     fieldpath: metadata.namespace
 - name: CERTIFICATE_NAME
   objref:
     kind: Certificate
-    group: certmanager.k8s.io
-    version: v1alpha1
+    group: cert-manager.io
+    version: v1alpha2
     name: serving-cert # this name should match the one in certificate.yaml
 - name: SERVICE_NAMESPACE # namespace of the service
   objref:

--- a/config/knative/default/webhookcainjection_patch.yaml
+++ b/config/knative/default/webhookcainjection_patch.yaml
@@ -5,11 +5,11 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)

--- a/config/riff-build.yaml
+++ b/config/riff-build.yaml
@@ -524,7 +524,7 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: riff-system/riff-build-serving-cert
+    cert-manager.io/inject-ca-from: riff-system/riff-build-serving-cert
   creationTimestamp: null
   labels:
     component: build.projectriff.io
@@ -995,7 +995,7 @@ spec:
           defaultMode: 420
           secretName: riff-build-webhook-server-cert
 ---
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   labels:
@@ -1005,13 +1005,14 @@ metadata:
 spec:
   commonName: riff-build-webhook-service.riff-system.svc
   dnsNames:
+  - riff-build-webhook-service.riff-system.svc
   - riff-build-webhook-service.riff-system.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: riff-build-selfsigned-issuer
   secretName: riff-build-webhook-server-cert
 ---
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   labels:
@@ -1025,7 +1026,7 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: riff-system/riff-build-serving-cert
+    cert-manager.io/inject-ca-from: riff-system/riff-build-serving-cert
   creationTimestamp: null
   labels:
     component: build.projectriff.io

--- a/config/riff-core.yaml
+++ b/config/riff-core.yaml
@@ -2724,7 +2724,7 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: riff-system/riff-core-serving-cert
+    cert-manager.io/inject-ca-from: riff-system/riff-core-serving-cert
   creationTimestamp: null
   labels:
     component: core.projectriff.io
@@ -3066,7 +3066,7 @@ spec:
           defaultMode: 420
           secretName: riff-core-webhook-server-cert
 ---
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   labels:
@@ -3076,13 +3076,14 @@ metadata:
 spec:
   commonName: riff-core-webhook-service.riff-system.svc
   dnsNames:
+  - riff-core-webhook-service.riff-system.svc
   - riff-core-webhook-service.riff-system.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: riff-core-selfsigned-issuer
   secretName: riff-core-webhook-server-cert
 ---
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   labels:
@@ -3096,7 +3097,7 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: riff-system/riff-core-serving-cert
+    cert-manager.io/inject-ca-from: riff-system/riff-core-serving-cert
   creationTimestamp: null
   labels:
     component: core.projectriff.io

--- a/config/riff-knative.yaml
+++ b/config/riff-knative.yaml
@@ -2822,7 +2822,7 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: riff-system/riff-knative-serving-cert
+    cert-manager.io/inject-ca-from: riff-system/riff-knative-serving-cert
   creationTimestamp: null
   labels:
     component: knative.projectriff.io
@@ -3192,7 +3192,7 @@ spec:
           defaultMode: 420
           secretName: riff-knative-webhook-server-cert
 ---
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   labels:
@@ -3202,13 +3202,14 @@ metadata:
 spec:
   commonName: riff-knative-webhook-service.riff-system.svc
   dnsNames:
+  - riff-knative-webhook-service.riff-system.svc
   - riff-knative-webhook-service.riff-system.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: riff-knative-selfsigned-issuer
   secretName: riff-knative-webhook-server-cert
 ---
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   labels:
@@ -3222,7 +3223,7 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: riff-system/riff-knative-serving-cert
+    cert-manager.io/inject-ca-from: riff-system/riff-knative-serving-cert
   creationTimestamp: null
   labels:
     component: knative.projectriff.io

--- a/config/riff-streaming.yaml
+++ b/config/riff-streaming.yaml
@@ -3019,7 +3019,7 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: riff-system/riff-streaming-serving-cert
+    cert-manager.io/inject-ca-from: riff-system/riff-streaming-serving-cert
   creationTimestamp: null
   labels:
     component: streaming.projectriff.io
@@ -3518,7 +3518,7 @@ spec:
           defaultMode: 420
           secretName: riff-streaming-webhook-server-cert
 ---
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   labels:
@@ -3528,13 +3528,14 @@ metadata:
 spec:
   commonName: riff-streaming-webhook-service.riff-system.svc
   dnsNames:
+  - riff-streaming-webhook-service.riff-system.svc
   - riff-streaming-webhook-service.riff-system.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: riff-streaming-selfsigned-issuer
   secretName: riff-streaming-webhook-server-cert
 ---
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   labels:
@@ -3548,7 +3549,7 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: riff-system/riff-streaming-serving-cert
+    cert-manager.io/inject-ca-from: riff-system/riff-streaming-serving-cert
   creationTimestamp: null
   labels:
     component: streaming.projectriff.io

--- a/config/streaming/certmanager/certificate.yaml
+++ b/config/streaming/certmanager/certificate.yaml
@@ -1,6 +1,6 @@
 # The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -8,7 +8,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
@@ -17,6 +17,7 @@ spec:
   # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
   commonName: $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
   dnsNames:
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
   issuerRef:
     kind: Issuer

--- a/config/streaming/certmanager/kustomizeconfig.yaml
+++ b/config/streaming/certmanager/kustomizeconfig.yaml
@@ -1,16 +1,16 @@
 # This configuration is for teaching kustomize how to update name ref and var substitution 
 nameReference:
 - kind: Issuer
-  group: certmanager.k8s.io
+  group: cert-manager.io
   fieldSpecs:
   - kind: Certificate
-    group: certmanager.k8s.io
+    group: cert-manager.io
     path: spec/issuerRef/name
 
 varReference:
 - kind: Certificate
-  group: certmanager.k8s.io
+  group: cert-manager.io
   path: spec/commonName
 - kind: Certificate
-  group: certmanager.k8s.io
+  group: cert-manager.io
   path: spec/dnsNames

--- a/config/streaming/crd/patches/cainjection_in_kafkaproviders.yaml
+++ b/config/streaming/crd/patches/cainjection_in_kafkaproviders.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
   name: kafkaproviders.streaming.projectriff.io

--- a/config/streaming/crd/patches/cainjection_in_processors.yaml
+++ b/config/streaming/crd/patches/cainjection_in_processors.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
   name: processors.streaming.projectriff.io

--- a/config/streaming/crd/patches/cainjection_in_streams.yaml
+++ b/config/streaming/crd/patches/cainjection_in_streams.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
   name: streams.streaming.projectriff.io

--- a/config/streaming/default/kustomization.yaml
+++ b/config/streaming/default/kustomization.yaml
@@ -48,16 +48,16 @@ vars:
 - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
   objref:
     kind: Certificate
-    group: certmanager.k8s.io
-    version: v1alpha1
+    group: cert-manager.io
+    version: v1alpha2
     name: serving-cert # this name should match the one in certificate.yaml
   fieldref:
     fieldpath: metadata.namespace
 - name: CERTIFICATE_NAME
   objref:
     kind: Certificate
-    group: certmanager.k8s.io
-    version: v1alpha1
+    group: cert-manager.io
+    version: v1alpha2
     name: serving-cert # this name should match the one in certificate.yaml
 - name: SERVICE_NAMESPACE # namespace of the service
   objref:

--- a/config/streaming/default/webhookcainjection_patch.yaml
+++ b/config/streaming/default/webhookcainjection_patch.yaml
@@ -5,11 +5,11 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)


### PR DESCRIPTION
- change api version from `certmanager.k8s.io/v1alpha1` to `cert-manager.io/v1alpha2`

- add `$(SERVICE_NAME).$(SERVICE_NAMESPACE).svc` DNS name in addition to the `.cluster.local` one to certs

Fixes #195 
Depends on projectriff/charts/pull/96 