### PR TITLE
Processor stream bindings

### DIFF
--- a/config/streaming/config/bases/processor.yaml
+++ b/config/streaming/config/bases/processor.yaml
@@ -3,4 +3,4 @@ kind: ConfigMap
 metadata:
   name: processor
 data:
-  processorImage: projectriff/streaming-processor:1.0.0-SNAPSHOT-20191104135401-334c4efa72a0d4c7
+  processorImage: projectriff/streaming-processor-native:1.0.0-SNAPSHOT-20191203102618-89ff1efe9c78c2e0

--- a/pkg/apis/streaming/v1alpha1/processor_defaults.go
+++ b/pkg/apis/streaming/v1alpha1/processor_defaults.go
@@ -57,4 +57,7 @@ func (s *ProcessorSpec) Default() {
 	if s.Template.Containers[0].Name == "" {
 		s.Template.Containers[0].Name = "function"
 	}
+	if s.Template.Volumes == nil {
+		s.Template.Volumes = []corev1.Volume{}
+	}
 }

--- a/pkg/apis/streaming/v1alpha1/processor_defaults_test.go
+++ b/pkg/apis/streaming/v1alpha1/processor_defaults_test.go
@@ -39,6 +39,7 @@ func TestProcessorDefault(t *testing.T) {
 					Containers: []corev1.Container{
 						{Name: "function"},
 					},
+					Volumes: []corev1.Volume{},
 				},
 			},
 		},
@@ -70,6 +71,7 @@ func TestProcessorSpecDefault(t *testing.T) {
 				Containers: []corev1.Container{
 					{Name: "function"},
 				},
+				Volumes: []corev1.Volume{},
 			},
 		},
 	}, {
@@ -92,6 +94,7 @@ func TestProcessorSpecDefault(t *testing.T) {
 				Containers: []corev1.Container{
 					{Name: "function"},
 				},
+				Volumes: []corev1.Volume{},
 			},
 		},
 	}, {
@@ -114,6 +117,7 @@ func TestProcessorSpecDefault(t *testing.T) {
 				Containers: []corev1.Container{
 					{Name: "function"},
 				},
+				Volumes: []corev1.Volume{},
 			},
 		},
 	}, {
@@ -132,6 +136,7 @@ func TestProcessorSpecDefault(t *testing.T) {
 				Containers: []corev1.Container{
 					{Name: "function"},
 				},
+				Volumes: []corev1.Volume{},
 			},
 		},
 	}, {
@@ -160,6 +165,7 @@ func TestProcessorSpecDefault(t *testing.T) {
 						},
 					},
 				},
+				Volumes: []corev1.Volume{},
 			},
 		},
 	}}

--- a/pkg/apis/streaming/v1alpha1/processor_types.go
+++ b/pkg/apis/streaming/v1alpha1/processor_types.go
@@ -81,12 +81,12 @@ type ProcessorStatus struct {
 
 	apis.Status `json:",inline"`
 
-	InputAddresses     []string `json:"inputAddresses,omitempty"`
-	OutputAddresses    []string `json:"outputAddresses,omitempty"`
-	OutputContentTypes []string `json:"outputContentTypes,omitempty"`
-	DeploymentName     string   `json:"deploymentName,omitempty"`
-	ScaledObjectName   string   `json:"scaledObjectName,omitempty"`
-	LatestImage        string   `json:"latestImage,omitempty"`
+	DeprecatedInputAddresses     []string `json:"inputAddresses,omitempty"`
+	DeprecatedOutputAddresses    []string `json:"outputAddresses,omitempty"`
+	DeprecatedOutputContentTypes []string `json:"outputContentTypes,omitempty"`
+	DeploymentName               string   `json:"deploymentName,omitempty"`
+	ScaledObjectName             string   `json:"scaledObjectName,omitempty"`
+	LatestImage                  string   `json:"latestImage,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/apis/streaming/v1alpha1/processor_validation_test.go
+++ b/pkg/apis/streaming/v1alpha1/processor_validation_test.go
@@ -194,10 +194,10 @@ func TestValidateProcessorSpec(t *testing.T) {
 				FunctionRef: "my-func",
 			},
 			Inputs: []StreamBinding{
-				{Stream: "my-stream", Alias: "my-alias"},
+				{Stream: "my-stream", Alias: "my-input"},
 			},
 			Outputs: []StreamBinding{
-				{Stream: "my-stream", Alias: "my-alias"},
+				{Stream: "my-stream", Alias: "my-output"},
 			},
 			Template: &corev1.PodSpec{
 				Containers: []corev1.Container{
@@ -207,16 +207,53 @@ func TestValidateProcessorSpec(t *testing.T) {
 		},
 		expected: validation.FieldErrors{},
 	}, {
+		name: "input alias collision",
+		target: &ProcessorSpec{
+			Build: &Build{
+				FunctionRef: "my-func",
+			},
+			Inputs: []StreamBinding{
+				{Stream: "my-stream1", Alias: "my-input"},
+				{Stream: "my-stream2", Alias: "my-input"},
+			},
+			Outputs: []StreamBinding{},
+			Template: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "function"},
+				},
+			},
+		},
+		expected: validation.ErrDuplicateValue("my-input", "inputs[0].alias", "inputs[1].alias"),
+	}, {
+		name: "input/output alias collision",
+		target: &ProcessorSpec{
+			Build: &Build{
+				FunctionRef: "my-func",
+			},
+			Inputs: []StreamBinding{
+				{Stream: "my-stream1", Alias: "my-alias"},
+			},
+			Outputs: []StreamBinding{
+				{Stream: "my-stream2", Alias: "my-alias"},
+			},
+			Template: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "function"},
+				},
+			},
+		},
+		expected: validation.ErrDuplicateValue("my-alias", "inputs[0].alias", "outputs[0].alias"),
+	}, {
 		name: "invalid container name",
 		target: &ProcessorSpec{
 			Build: &Build{
 				FunctionRef: "my-func",
 			},
 			Inputs: []StreamBinding{
-				{Stream: "my-stream", Alias: "my-alias"},
+				{Stream: "my-stream", Alias: "my-input"},
 			},
 			Outputs: []StreamBinding{
-				{Stream: "my-stream", Alias: "my-alias"},
+				{Stream: "my-stream", Alias: "my-output"},
 			},
 			Template: &corev1.PodSpec{
 				Containers: []corev1.Container{

--- a/pkg/apis/streaming/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/streaming/v1alpha1/zz_generated.deepcopy.go
@@ -245,18 +245,18 @@ func (in *ProcessorSpec) DeepCopy() *ProcessorSpec {
 func (in *ProcessorStatus) DeepCopyInto(out *ProcessorStatus) {
 	*out = *in
 	in.Status.DeepCopyInto(&out.Status)
-	if in.InputAddresses != nil {
-		in, out := &in.InputAddresses, &out.InputAddresses
+	if in.DeprecatedInputAddresses != nil {
+		in, out := &in.DeprecatedInputAddresses, &out.DeprecatedInputAddresses
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.OutputAddresses != nil {
-		in, out := &in.OutputAddresses, &out.OutputAddresses
+	if in.DeprecatedOutputAddresses != nil {
+		in, out := &in.DeprecatedOutputAddresses, &out.DeprecatedOutputAddresses
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.OutputContentTypes != nil {
-		in, out := &in.OutputContentTypes, &out.OutputContentTypes
+	if in.DeprecatedOutputContentTypes != nil {
+		in, out := &in.DeprecatedOutputContentTypes, &out.DeprecatedOutputContentTypes
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/pkg/controllers/streaming/processor_controller.go
+++ b/pkg/controllers/streaming/processor_controller.go
@@ -178,15 +178,15 @@ func (r *ProcessorReconciler) reconcile(ctx context.Context, logger logr.Logger,
 	if err != nil {
 		return ctrl.Result{Requeue: true}, err
 	}
-	processor.Status.InputAddresses = r.collectStreamAddresses(inputStreams)
+	processor.Status.DeprecatedInputAddresses = r.collectStreamAddresses(inputStreams)
 
 	// Resolve output addresses
 	outputStreams, err := r.resolveStreams(ctx, processorNSName, processor.Spec.Outputs)
 	if err != nil {
 		return ctrl.Result{Requeue: true}, err
 	}
-	processor.Status.OutputAddresses = r.collectStreamAddresses(outputStreams)
-	processor.Status.OutputContentTypes = r.collectStreamContentTypes(outputStreams)
+	processor.Status.DeprecatedOutputAddresses = r.collectStreamAddresses(outputStreams)
+	processor.Status.DeprecatedOutputContentTypes = r.collectStreamContentTypes(outputStreams)
 
 	// Reconcile deployment for processor
 	deployment, err := r.reconcileProcessorDeployment(ctx, logger, processor, &cm)
@@ -326,8 +326,8 @@ func (r *ProcessorReconciler) constructScaledObjectForProcessor(processor *strea
 }
 
 func triggers(proc *streamingv1alpha1.Processor) []kedav1alpha1.ScaleTriggers {
-	result := make([]kedav1alpha1.ScaleTriggers, len(proc.Status.InputAddresses))
-	for i, topic := range proc.Status.InputAddresses {
+	result := make([]kedav1alpha1.ScaleTriggers, len(proc.Status.DeprecatedInputAddresses))
+	for i, topic := range proc.Status.DeprecatedInputAddresses {
 		result[i].Type = "liiklus"
 		result[i].Metadata = map[string]string{
 			"address": strings.SplitN(topic, "/", 2)[0],
@@ -521,7 +521,7 @@ func (r *ProcessorReconciler) collectStreamContentTypes(streams []streamingv1alp
 }
 
 func (r *ProcessorReconciler) computeEnvironmentVariables(processor *streamingv1alpha1.Processor) ([]v1.EnvVar, error) {
-	contentTypesJson, err := json.Marshal(processor.Status.OutputContentTypes)
+	contentTypesJson, err := json.Marshal(processor.Status.DeprecatedOutputContentTypes)
 	if err != nil {
 		return nil, err
 	}
@@ -530,11 +530,11 @@ func (r *ProcessorReconciler) computeEnvironmentVariables(processor *streamingv1
 	return []v1.EnvVar{
 		{
 			Name:  "INPUTS",
-			Value: strings.Join(processor.Status.InputAddresses, ","),
+			Value: strings.Join(processor.Status.DeprecatedInputAddresses, ","),
 		},
 		{
 			Name:  "OUTPUTS",
-			Value: strings.Join(processor.Status.OutputAddresses, ","),
+			Value: strings.Join(processor.Status.DeprecatedOutputAddresses, ","),
 		},
 		{
 			Name:  "INPUT_NAMES",

--- a/pkg/controllers/streaming/processor_controller.go
+++ b/pkg/controllers/streaming/processor_controller.go
@@ -432,7 +432,7 @@ func (r *ProcessorReconciler) constructDeploymentForProcessor(processor *streami
 	streamBindings := append(processor.Spec.Inputs, processor.Spec.Outputs...)
 	for i, stream := range streams {
 		if stream.Status.Binding.MetadataRef.Name != "" {
-			metadataVolumeName := fmt.Sprintf("processor-stream-%s-metadata", stream.Name)
+			metadataVolumeName := fmt.Sprintf("processor-stream-%s-metadata", streamBindings[i].Alias)
 			volumes = append(volumes,
 				corev1.Volume{
 					Name: metadataVolumeName,
@@ -454,7 +454,7 @@ func (r *ProcessorReconciler) constructDeploymentForProcessor(processor *streami
 			)
 		}
 		if stream.Status.Binding.SecretRef.Name != "" {
-			secretVolumeName := fmt.Sprintf("processor-stream-%s-secret", stream.Name)
+			secretVolumeName := fmt.Sprintf("processor-stream-%s-secret", streamBindings[i].Alias)
 			volumes = append(volumes,
 				corev1.Volume{
 					Name: secretVolumeName,

--- a/pkg/controllers/streaming/stream_controller.go
+++ b/pkg/controllers/streaming/stream_controller.go
@@ -217,9 +217,12 @@ func (r *StreamReconciler) constructBindingMetadata(stream *streamingv1alpha1.St
 			Namespace:   stream.Namespace,
 		},
 		Data: map[string]string{
+			// spec required values
 			"kind":     (&streamingv1alpha1.Stream{}).GetGroupVersionKind().GroupKind().String(),
 			"provider": stream.Name,
 			"tags":     "",
+			// non-spec values
+			"contentType": stream.Spec.ContentType,
 		},
 	}
 	if err := ctrl.SetControllerReference(stream, metadata, r.Scheme); err != nil {

--- a/pkg/controllers/streaming/stream_controller.go
+++ b/pkg/controllers/streaming/stream_controller.go
@@ -219,9 +219,10 @@ func (r *StreamReconciler) constructBindingMetadata(stream *streamingv1alpha1.St
 		Data: map[string]string{
 			// spec required values
 			"kind":     (&streamingv1alpha1.Stream{}).GetGroupVersionKind().GroupKind().String(),
-			"provider": stream.Name,
+			"provider": "riff Streaming",
 			"tags":     "",
 			// non-spec values
+			"stream":      stream.Name,
 			"contentType": stream.Spec.ContentType,
 		},
 	}

--- a/pkg/validation/fielderrors.go
+++ b/pkg/validation/fielderrors.go
@@ -118,6 +118,16 @@ func ErrInvalidValue(value interface{}, name string) FieldErrors {
 	}
 }
 
+func ErrDuplicateValue(value interface{}, names ...string) FieldErrors {
+	errs := FieldErrors{}
+
+	for _, name := range names {
+		errs = append(errs, field.Duplicate(field.NewPath(name), value))
+	}
+
+	return errs
+}
+
 func ErrMissingField(name string) FieldErrors {
 	return FieldErrors{
 		field.Required(field.NewPath(name), ""),

--- a/pkg/validation/fielderrors_test.go
+++ b/pkg/validation/fielderrors_test.go
@@ -171,6 +171,28 @@ func TestErrInvalidValue(t *testing.T) {
 	}
 }
 
+func TestErrDuplicateValue(t *testing.T) {
+	expected := validation.FieldErrors{
+		&field.Error{
+			Type:     field.ErrorTypeDuplicate,
+			Field:    "my-field1",
+			BadValue: "value",
+			Detail:   "",
+		},
+		&field.Error{
+			Type:     field.ErrorTypeDuplicate,
+			Field:    "my-field2",
+			BadValue: "value",
+			Detail:   "",
+		},
+	}
+	actual := validation.ErrDuplicateValue("value", "my-field1", "my-field2")
+
+	if diff := cmp.Diff(expected, actual); diff != "" {
+		t.Errorf("(-expected, +actual): %s", diff)
+	}
+}
+
 func TestErrMissingField(t *testing.T) {
 	expected := validation.FieldErrors{
 		&field.Error{


### PR DESCRIPTION
Consume stream bindings on the Processor's processor container. The processor image still needs to be updated in order to consume the bindings.

Once the processor image is updated, fields marked by this PR as deprecated can be removed.

Refs #198, [RFC 0002](https://github.com/projectriff/riff/blob/master/rfc/rfc-0002-bindings.md)