### PR TITLE
Don't use PullAlways for processor image.

### DIFF
--- a/pkg/controllers/streaming/processor_controller.go
+++ b/pkg/controllers/streaming/processor_controller.go
@@ -529,7 +529,7 @@ func (r *ProcessorReconciler) constructDeploymentForProcessor(processor *streami
 	podSpec.Containers = append(podSpec.Containers, v1.Container{
 		Name:            "processor",
 		Image:           processorImg,
-		ImagePullPolicy: v1.PullAlways,
+		ImagePullPolicy: v1.PullIfNotPresent,
 		Env:             environmentVariables,
 		VolumeMounts:    volumeMounts,
 	})


### PR DESCRIPTION
Fixes #211

This was useful when prototyping, but now that we have easy access
to content digested images, this has become counter-productive.