### PR TITLE
Properly Watch() the processor image ConfigMap

### DIFF
--- a/config/riff-streaming.yaml
+++ b/config/riff-streaming.yaml
@@ -3170,6 +3170,12 @@ rules:
   - build.projectriff.io
   resources:
   - containers
+  verbs:
+  - get
+  - watch
+- apiGroups:
+  - build.projectriff.io
+  resources:
   - functions
   verbs:
   - get

--- a/config/streaming/rbac/role.yaml
+++ b/config/streaming/rbac/role.yaml
@@ -22,6 +22,12 @@ rules:
   - build.projectriff.io
   resources:
   - containers
+  verbs:
+  - get
+  - watch
+- apiGroups:
+  - build.projectriff.io
+  resources:
   - functions
   verbs:
   - get


### PR DESCRIPTION
Fixes #209

Without this fix, changing the value in the ConfigMap did not trigger
a change in the deployed processors.