### PR TITLE
Keep test factories

### DIFF
--- a/pkg/controllers/build/clusterbuilder_controller_test.go
+++ b/pkg/controllers/build/clusterbuilder_controller_test.go
@@ -46,78 +46,73 @@ func TestClusterBuildersReconcile(t *testing.T) {
 
 	testApplicationBuilder := factories.KpackClusterBuilder().
 		NamespaceName("", "riff-application").
-		Image(testApplicationImage).
-		Get()
-	testApplicationBuilderReady := factories.KpackClusterBuilder(testApplicationBuilder).
+		Image(testApplicationImage)
+	testApplicationBuilderReady := testApplicationBuilder.
 		StatusReady().
-		StatusLatestImage(testApplicationImage).
-		Get()
+		StatusLatestImage(testApplicationImage)
 	testFunctionBuilder := factories.KpackClusterBuilder().
 		NamespaceName("", "riff-function").
-		Image(testFunctionImage).
-		Get()
-	testFunctionBuilderReady := factories.KpackClusterBuilder(testFunctionBuilder).
+		Image(testFunctionImage)
+	testFunctionBuilderReady := testFunctionBuilder.
 		StatusReady().
-		StatusLatestImage(testFunctionImage).
-		Get()
+		StatusLatestImage(testFunctionImage)
 
 	testBuilders := factories.ConfigMap().
-		NamespaceName(testNamespace, testName).
-		Get()
+		NamespaceName(testNamespace, testName)
 
 	table := rtesting.Table{{
 		Name: "builders configmap does not exist",
 		Key:  testKey,
 		ExpectCreates: []runtime.Object{
-			testBuilders,
+			testBuilders.Get(),
 		},
 	}, {
 		Name: "builders configmap unchanged",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			testBuilders,
+			testBuilders.Get(),
 		},
 	}, {
 		Name: "ignore deleted builders configmap",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.ConfigMap(testBuilders).
+			testBuilders.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.Deleted(1)
 				}).
 				Get(),
-			testApplicationBuilder,
-			testFunctionBuilder,
+			testApplicationBuilder.Get(),
+			testFunctionBuilder.Get(),
 		},
 	}, {
 		Name: "ignore other configmaps in the correct namespace",
 		Key:  types.NamespacedName{Namespace: testNamespace, Name: "not-builders"},
 		GivenObjects: []runtime.Object{
-			factories.ConfigMap(testBuilders).
+			testBuilders.
 				NamespaceName(testNamespace, "not-builders").
 				Get(),
-			testApplicationBuilder,
-			testFunctionBuilder,
+			testApplicationBuilder.Get(),
+			testFunctionBuilder.Get(),
 		},
 	}, {
 		Name: "ignore other configmaps in the wrong namespace",
 		Key:  types.NamespacedName{Namespace: "not-riff-system", Name: testName},
 		GivenObjects: []runtime.Object{
-			factories.ConfigMap(testBuilders).
+			testBuilders.
 				NamespaceName("not-riff-system", testName).
 				Get(),
-			testApplicationBuilder,
-			testFunctionBuilder,
+			testApplicationBuilder.Get(),
+			testFunctionBuilder.Get(),
 		},
 	}, {
 		Name: "create builders configmap, not ready",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			testApplicationBuilder,
-			testFunctionBuilder,
+			testApplicationBuilder.Get(),
+			testFunctionBuilder.Get(),
 		},
 		ExpectCreates: []runtime.Object{
-			factories.ConfigMap(testBuilders).
+			testBuilders.
 				AddData("riff-application", "").
 				AddData("riff-function", "").
 				Get(),
@@ -126,11 +121,11 @@ func TestClusterBuildersReconcile(t *testing.T) {
 		Name: "create builders configmap, ready",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			testApplicationBuilderReady,
-			testFunctionBuilderReady,
+			testApplicationBuilderReady.Get(),
+			testFunctionBuilderReady.Get(),
 		},
 		ExpectCreates: []runtime.Object{
-			factories.ConfigMap(testBuilders).
+			testBuilders.
 				AddData("riff-application", testApplicationImage).
 				AddData("riff-function", testFunctionImage).
 				Get(),
@@ -142,12 +137,12 @@ func TestClusterBuildersReconcile(t *testing.T) {
 			rtesting.InduceFailure("create", "ConfigMap"),
 		},
 		GivenObjects: []runtime.Object{
-			testApplicationBuilder,
-			testFunctionBuilder,
+			testApplicationBuilder.Get(),
+			testFunctionBuilder.Get(),
 		},
 		ShouldErr: true,
 		ExpectCreates: []runtime.Object{
-			factories.ConfigMap(testBuilders).
+			testBuilders.
 				AddData("riff-application", "").
 				AddData("riff-function", "").
 				Get(),
@@ -156,12 +151,12 @@ func TestClusterBuildersReconcile(t *testing.T) {
 		Name: "update builders configmap",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			testBuilders,
-			testApplicationBuilderReady,
-			testFunctionBuilderReady,
+			testBuilders.Get(),
+			testApplicationBuilderReady.Get(),
+			testFunctionBuilderReady.Get(),
 		},
 		ExpectUpdates: []runtime.Object{
-			factories.ConfigMap(testBuilders).
+			testBuilders.
 				AddData("riff-application", testApplicationImage).
 				AddData("riff-function", testFunctionImage).
 				Get(),
@@ -173,13 +168,13 @@ func TestClusterBuildersReconcile(t *testing.T) {
 			rtesting.InduceFailure("update", "ConfigMap"),
 		},
 		GivenObjects: []runtime.Object{
-			testBuilders,
-			testApplicationBuilderReady,
-			testFunctionBuilderReady,
+			testBuilders.Get(),
+			testApplicationBuilderReady.Get(),
+			testFunctionBuilderReady.Get(),
 		},
 		ShouldErr: true,
 		ExpectUpdates: []runtime.Object{
-			factories.ConfigMap(testBuilders).
+			testBuilders.
 				AddData("riff-application", testApplicationImage).
 				AddData("riff-function", testFunctionImage).
 				Get(),
@@ -191,9 +186,9 @@ func TestClusterBuildersReconcile(t *testing.T) {
 			rtesting.InduceFailure("get", "ConfigMap"),
 		},
 		GivenObjects: []runtime.Object{
-			testBuilders,
-			testApplicationBuilder,
-			testFunctionBuilder,
+			testBuilders.Get(),
+			testApplicationBuilder.Get(),
+			testFunctionBuilder.Get(),
 		},
 		ShouldErr: true,
 	}, {
@@ -203,9 +198,9 @@ func TestClusterBuildersReconcile(t *testing.T) {
 			rtesting.InduceFailure("list", "ClusterBuilderList"),
 		},
 		GivenObjects: []runtime.Object{
-			testBuilders,
-			testApplicationBuilder,
-			testFunctionBuilder,
+			testBuilders.Get(),
+			testApplicationBuilder.Get(),
+			testFunctionBuilder.Get(),
 		},
 		ShouldErr: true,
 	}}

--- a/pkg/controllers/build/container_controller_test.go
+++ b/pkg/controllers/build/container_controller_test.go
@@ -49,20 +49,16 @@ func TestContainerReconcile(t *testing.T) {
 	_ = buildv1alpha1.AddToScheme(scheme)
 
 	containerMinimal := factories.Container().
-		NamespaceName(testNamespace, testName).
-		Get()
-	containerValid := factories.Container(containerMinimal).
-		Image("%s/%s", testImagePrefix, testName).
-		Get()
+		NamespaceName(testNamespace, testName)
+	containerValid := containerMinimal.
+		Image("%s/%s", testImagePrefix, testName)
 
 	cmImagePrefix := factories.ConfigMap().
 		NamespaceName(testNamespace, "riff-build").
-		AddData("default-image-prefix", "").
-		Get()
+		AddData("default-image-prefix", "")
 
 	serviceAccount := factories.ServiceAccount().
-		NamespaceName(testNamespace, "riff-build").
-		Get()
+		NamespaceName(testNamespace, "riff-build")
 
 	table := rtesting.Table{{
 		Name: "container does not exist",
@@ -71,7 +67,7 @@ func TestContainerReconcile(t *testing.T) {
 		Name: "ignore deleted container",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.Container(containerValid).
+			containerValid.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.Deleted(1)
 				}).
@@ -83,11 +79,11 @@ func TestContainerReconcile(t *testing.T) {
 		Name: "resolve images digest",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			containerValid,
-			serviceAccount,
+			containerValid.Get(),
+			serviceAccount.Get(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.Container(containerMinimal).
+			containerMinimal.
 				StatusConditions(
 					apis.Condition{
 						Type:   buildv1alpha1.ContainerConditionImageResolved,
@@ -115,14 +111,14 @@ func TestContainerReconcile(t *testing.T) {
 		Name: "default image",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.ConfigMap(cmImagePrefix).
+			cmImagePrefix.
 				AddData("default-image-prefix", testImagePrefix).
 				Get(),
-			containerMinimal,
-			serviceAccount,
+			containerMinimal.Get(),
+			serviceAccount.Get(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.Container(containerMinimal).
+			containerMinimal.
 				StatusConditions(
 					apis.Condition{
 						Type:   buildv1alpha1.ContainerConditionImageResolved,
@@ -140,10 +136,10 @@ func TestContainerReconcile(t *testing.T) {
 		Name: "default image, missing",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			containerMinimal,
+			containerMinimal.Get(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.Container(containerMinimal).
+			containerMinimal.
 				StatusConditions(
 					apis.Condition{
 						Type:    buildv1alpha1.ContainerConditionImageResolved,
@@ -165,11 +161,11 @@ func TestContainerReconcile(t *testing.T) {
 		Name: "default image, undefined",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			cmImagePrefix,
-			containerMinimal,
+			cmImagePrefix.Get(),
+			containerMinimal.Get(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.Container(containerMinimal).
+			containerMinimal.
 				StatusConditions(
 					apis.Condition{
 						Type:    buildv1alpha1.ContainerConditionImageResolved,
@@ -194,11 +190,11 @@ func TestContainerReconcile(t *testing.T) {
 			rtesting.InduceFailure("get", "ConfigMap"),
 		},
 		GivenObjects: []runtime.Object{
-			cmImagePrefix,
-			containerMinimal,
+			cmImagePrefix.Get(),
+			containerMinimal.Get(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.Container(containerMinimal).
+			containerMinimal.
 				StatusConditions(
 					apis.Condition{
 						Type:    buildv1alpha1.ContainerConditionImageResolved,
@@ -225,11 +221,11 @@ func TestContainerReconcile(t *testing.T) {
 			rtesting.InduceFailure("update", "Container"),
 		},
 		GivenObjects: []runtime.Object{
-			containerValid,
-			serviceAccount,
+			containerValid.Get(),
+			serviceAccount.Get(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.Container(containerMinimal).
+			containerMinimal.
 				StatusConditions(
 					apis.Condition{
 						Type:   buildv1alpha1.ContainerConditionImageResolved,

--- a/pkg/controllers/build/credential_controller_test.go
+++ b/pkg/controllers/build/credential_controller_test.go
@@ -43,24 +43,19 @@ func TestCredentialsReconcile(t *testing.T) {
 	_ = buildv1alpha1.AddToScheme(scheme)
 
 	testServiceAccount := factories.ServiceAccount().
-		NamespaceName(testNamespace, testName).
-		Get()
+		NamespaceName(testNamespace, testName)
 	testCredential := factories.Secret().
 		ObjectMeta(func(om factories.ObjectMeta) {
 			om.AddLabel(buildv1alpha1.CredentialLabelKey, "docker-hub")
 		}).
-		NamespaceName(testNamespace, "my-credential").
-		Get()
+		NamespaceName(testNamespace, "my-credential")
 
 	testApplication := factories.Application().
-		NamespaceName(testNamespace, "my-application").
-		Get()
+		NamespaceName(testNamespace, "my-application")
 	testFunction := factories.Function().
-		NamespaceName(testNamespace, "my-function").
-		Get()
+		NamespaceName(testNamespace, "my-function")
 	testContainer := factories.Container().
-		NamespaceName(testNamespace, "my-container").
-		Get()
+		NamespaceName(testNamespace, "my-container")
 
 	table := rtesting.Table{{
 		Name: "service account does not exist",
@@ -69,7 +64,7 @@ func TestCredentialsReconcile(t *testing.T) {
 		Name: "ignore deleted service account",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.ServiceAccount(testServiceAccount).
+			testServiceAccount.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.Deleted(1)
 				}).
@@ -79,7 +74,7 @@ func TestCredentialsReconcile(t *testing.T) {
 		Name: "ignore non-build service accounts",
 		Key:  types.NamespacedName{Namespace: testNamespace, Name: "not-riff-build"},
 		GivenObjects: []runtime.Object{
-			factories.ServiceAccount(testServiceAccount).
+			testServiceAccount.
 				NamespaceName(testNamespace, "not-riff-build").
 				Get(),
 		},
@@ -90,17 +85,17 @@ func TestCredentialsReconcile(t *testing.T) {
 			rtesting.InduceFailure("get", "ServiceAccount"),
 		},
 		GivenObjects: []runtime.Object{
-			testServiceAccount,
+			testServiceAccount.Get(),
 		},
 		ShouldErr: true,
 	}, {
 		Name: "create service account for application",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			testApplication,
+			testApplication.Get(),
 		},
 		ExpectCreates: []runtime.Object{
-			factories.ServiceAccount(testServiceAccount).
+			testServiceAccount.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.AddAnnotation("build.projectriff.io/credentials", "")
 				}).
@@ -113,17 +108,17 @@ func TestCredentialsReconcile(t *testing.T) {
 			rtesting.InduceFailure("list", "ApplicationList"),
 		},
 		GivenObjects: []runtime.Object{
-			testApplication,
+			testApplication.Get(),
 		},
 		ShouldErr: true,
 	}, {
 		Name: "create service account for function",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			testFunction,
+			testFunction.Get(),
 		},
 		ExpectCreates: []runtime.Object{
-			factories.ServiceAccount(testServiceAccount).
+			testServiceAccount.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.AddAnnotation("build.projectriff.io/credentials", "")
 				}).
@@ -136,17 +131,17 @@ func TestCredentialsReconcile(t *testing.T) {
 			rtesting.InduceFailure("list", "FunctionList"),
 		},
 		GivenObjects: []runtime.Object{
-			testFunction,
+			testFunction.Get(),
 		},
 		ShouldErr: true,
 	}, {
 		Name: "create service account for container",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			testContainer,
+			testContainer.Get(),
 		},
 		ExpectCreates: []runtime.Object{
-			factories.ServiceAccount(testServiceAccount).
+			testServiceAccount.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.AddAnnotation("build.projectriff.io/credentials", "")
 				}).
@@ -159,21 +154,21 @@ func TestCredentialsReconcile(t *testing.T) {
 			rtesting.InduceFailure("list", "ContainerList"),
 		},
 		GivenObjects: []runtime.Object{
-			testContainer,
+			testContainer.Get(),
 		},
 		ShouldErr: true,
 	}, {
 		Name: "create service account for credential",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			testCredential,
+			testCredential.Get(),
 		},
 		ExpectCreates: []runtime.Object{
-			factories.ServiceAccount(testServiceAccount).
+			testServiceAccount.
 				ObjectMeta(func(om factories.ObjectMeta) {
-					om.AddAnnotation("build.projectriff.io/credentials", testCredential.Name)
+					om.AddAnnotation("build.projectriff.io/credentials", testCredential.Get().Name)
 				}).
-				Secrets(testCredential.Name).
+				Secrets(testCredential.Get().Name).
 				Get(),
 		},
 	}, {
@@ -183,7 +178,7 @@ func TestCredentialsReconcile(t *testing.T) {
 			rtesting.InduceFailure("list", "SecretList"),
 		},
 		GivenObjects: []runtime.Object{
-			testCredential,
+			testCredential.Get(),
 		},
 		ShouldErr: true,
 	}, {
@@ -193,46 +188,46 @@ func TestCredentialsReconcile(t *testing.T) {
 			rtesting.InduceFailure("create", "ServiceAccount"),
 		},
 		GivenObjects: []runtime.Object{
-			testCredential,
+			testCredential.Get(),
 		},
 		ShouldErr: true,
 		ExpectCreates: []runtime.Object{
-			factories.ServiceAccount(testServiceAccount).
+			testServiceAccount.
 				ObjectMeta(func(om factories.ObjectMeta) {
-					om.AddAnnotation("build.projectriff.io/credentials", testCredential.Name)
+					om.AddAnnotation("build.projectriff.io/credentials", testCredential.Get().Name)
 				}).
-				Secrets(testCredential.Name).
+				Secrets(testCredential.Get().Name).
 				Get(),
 		},
 	}, {
 		Name: "add credential to service account",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			testServiceAccount,
-			testCredential,
+			testServiceAccount.Get(),
+			testCredential.Get(),
 		},
 		ExpectUpdates: []runtime.Object{
-			factories.ServiceAccount(testServiceAccount).
+			testServiceAccount.
 				ObjectMeta(func(om factories.ObjectMeta) {
-					om.AddAnnotation("build.projectriff.io/credentials", testCredential.Name)
+					om.AddAnnotation("build.projectriff.io/credentials", testCredential.Get().Name)
 				}).
-				Secrets(testCredential.Name).
+				Secrets(testCredential.Get().Name).
 				Get(),
 		},
 	}, {
 		Name: "add credentials to service account",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			testServiceAccount,
-			factories.Secret(testCredential).
+			testServiceAccount.Get(),
+			testCredential.
 				NamespaceName(testNamespace, "cred-1").
 				Get(),
-			factories.Secret(testCredential).
+			testCredential.
 				NamespaceName(testNamespace, "cred-2").
 				Get(),
 		},
 		ExpectUpdates: []runtime.Object{
-			factories.ServiceAccount(testServiceAccount).
+			testServiceAccount.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.AddAnnotation("build.projectriff.io/credentials", "cred-1,cred-2")
 				}).
@@ -246,8 +241,8 @@ func TestCredentialsReconcile(t *testing.T) {
 			rtesting.InduceFailure("list", "SecretList"),
 		},
 		GivenObjects: []runtime.Object{
-			testServiceAccount,
-			testCredential,
+			testServiceAccount.Get(),
+			testCredential.Get(),
 		},
 		ShouldErr: true,
 	}, {
@@ -257,34 +252,34 @@ func TestCredentialsReconcile(t *testing.T) {
 			rtesting.InduceFailure("update", "ServiceAccount"),
 		},
 		GivenObjects: []runtime.Object{
-			testServiceAccount,
-			testCredential,
+			testServiceAccount.Get(),
+			testCredential.Get(),
 		},
 		ShouldErr: true,
 		ExpectUpdates: []runtime.Object{
-			factories.ServiceAccount(testServiceAccount).
+			testServiceAccount.
 				ObjectMeta(func(om factories.ObjectMeta) {
-					om.AddAnnotation("build.projectriff.io/credentials", testCredential.Name)
+					om.AddAnnotation("build.projectriff.io/credentials", testCredential.Get().Name)
 				}).
-				Secrets(testCredential.Name).
+				Secrets(testCredential.Get().Name).
 				Get(),
 		},
 	}, {
 		Name: "add credentials to service account, preserving non-credential bound secrets",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.ServiceAccount(testServiceAccount).
+			testServiceAccount.
 				Secrets("keep-me").
 				Get(),
-			factories.Secret(testCredential).
+			testCredential.
 				NamespaceName(testNamespace, "cred-1").
 				Get(),
-			factories.Secret(testCredential).
+			testCredential.
 				NamespaceName(testNamespace, "cred-2").
 				Get(),
 		},
 		ExpectUpdates: []runtime.Object{
-			factories.ServiceAccount(testServiceAccount).
+			testServiceAccount.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.AddAnnotation("build.projectriff.io/credentials", "cred-1,cred-2")
 				}).
@@ -295,7 +290,7 @@ func TestCredentialsReconcile(t *testing.T) {
 		Name: "ignore non-credential secrets for service account",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.ServiceAccount(testServiceAccount).
+			testServiceAccount.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.AddAnnotation("build.projectriff.io/credentials", "")
 				}).
@@ -309,37 +304,39 @@ func TestCredentialsReconcile(t *testing.T) {
 		Name: "remove credential from service account",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.ServiceAccount(testServiceAccount).
+			testServiceAccount.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.AddAnnotation("build.projectriff.io/credentials", "cred-1,cred-2")
 				}).
 				Secrets("cred-1", "cred-2").
 				Get(),
 		},
-		ExpectUpdates: []runtime.Object{factories.ServiceAccount(testServiceAccount).
-			ObjectMeta(func(om factories.ObjectMeta) {
-				om.AddAnnotation("build.projectriff.io/credentials", "")
-			}).
-			Secrets().
-			Get(),
+		ExpectUpdates: []runtime.Object{
+			testServiceAccount.
+				ObjectMeta(func(om factories.ObjectMeta) {
+					om.AddAnnotation("build.projectriff.io/credentials", "")
+				}).
+				Secrets().
+				Get(),
 		},
 	}, {
 		Name: "remove credential from service account, preserving non-credential bound secrets",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.ServiceAccount(testServiceAccount).
+			testServiceAccount.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.AddAnnotation("build.projectriff.io/credentials", "cred-1,cred-2")
 				}).
 				Secrets("keep-me", "cred-1", "cred-2").
 				Get(),
 		},
-		ExpectUpdates: []runtime.Object{factories.ServiceAccount(testServiceAccount).
-			ObjectMeta(func(om factories.ObjectMeta) {
-				om.AddAnnotation("build.projectriff.io/credentials", "")
-			}).
-			Secrets("keep-me").
-			Get(),
+		ExpectUpdates: []runtime.Object{
+			testServiceAccount.
+				ObjectMeta(func(om factories.ObjectMeta) {
+					om.AddAnnotation("build.projectriff.io/credentials", "")
+				}).
+				Secrets("keep-me").
+				Get(),
 		},
 	}}
 

--- a/pkg/controllers/build/function_controller_test.go
+++ b/pkg/controllers/build/function_controller_test.go
@@ -59,37 +59,32 @@ func TestFunctionReconcile(t *testing.T) {
 	_ = buildv1alpha1.AddToScheme(scheme)
 
 	funcMinimal := factories.Function().
-		NamespaceName(testNamespace, testName).
-		Get()
-	funcValid := factories.Function(funcMinimal).
+		NamespaceName(testNamespace, testName)
+	funcValid := funcMinimal.
 		Image("%s/%s", testImagePrefix, testName).
-		SourceGit(testGitUrl, testGitRevision).
-		Get()
+		SourceGit(testGitUrl, testGitRevision)
 
 	kpackImageCreate := factories.KpackImage().
 		ObjectMeta(func(om factories.ObjectMeta) {
 			om.Namespace(testNamespace).
 				GenerateName("%s-function-", testName).
 				AddLabel(buildv1alpha1.FunctionLabelKey, testName).
-				ControlledBy(funcMinimal, scheme)
+				ControlledBy(funcMinimal.Get(), scheme)
 		}).
 		Tag("%s/%s", testImagePrefix, testName).
 		FunctionBuilder("", "", "").
-		SourceGit(testGitUrl, testGitRevision).
-		Get()
-	kpackImageGiven := factories.KpackImage(kpackImageCreate).
+		SourceGit(testGitUrl, testGitRevision)
+	kpackImageGiven := kpackImageCreate.
 		ObjectMeta(func(om factories.ObjectMeta) {
 			om.
 				Name("%s-function-001", testName).
 				Generation(1)
 		}).
-		StatusObservedGeneration(1).
-		Get()
+		StatusObservedGeneration(1)
 
 	cmImagePrefix := factories.ConfigMap().
 		NamespaceName(testNamespace, "riff-build").
-		AddData("default-image-prefix", "").
-		Get()
+		AddData("default-image-prefix", "")
 
 	table := rtesting.Table{{
 		Name: "function does not exist",
@@ -98,7 +93,7 @@ func TestFunctionReconcile(t *testing.T) {
 		Name: "ignore deleted function",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.Function(funcValid).
+			funcValid.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.Deleted(1)
 				}).
@@ -115,13 +110,13 @@ func TestFunctionReconcile(t *testing.T) {
 		Name: "create kpack image",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			funcValid,
+			funcValid.Get(),
 		},
 		ExpectCreates: []runtime.Object{
-			kpackImageCreate,
+			kpackImageCreate.Get(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.Function(funcMinimal).
+			funcMinimal.
 				StatusConditions(
 					apis.Condition{
 						Type:   buildv1alpha1.FunctionConditionImageResolved,
@@ -144,19 +139,19 @@ func TestFunctionReconcile(t *testing.T) {
 		Name: "create kpack image, function properties",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.Function(funcValid).
+			funcValid.
 				Artifact(testArtifact).
 				Handler(testHandler).
 				Invoker(testInvoker).
 				Get(),
 		},
 		ExpectCreates: []runtime.Object{
-			factories.KpackImage(kpackImageCreate).
+			kpackImageCreate.
 				FunctionBuilder(testArtifact, testHandler, testInvoker).
 				Get(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.Function(funcMinimal).
+			funcMinimal.
 				StatusConditions(
 					apis.Condition{
 						Type:   buildv1alpha1.FunctionConditionImageResolved,
@@ -179,17 +174,17 @@ func TestFunctionReconcile(t *testing.T) {
 		Name: "create kpack image, build cache",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.Function(funcValid).
+			funcValid.
 				BuildCache("1Gi").
 				Get(),
 		},
 		ExpectCreates: []runtime.Object{
-			factories.KpackImage(kpackImageCreate).
+			kpackImageCreate.
 				BuildCache("1Gi").
 				Get(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.Function(funcMinimal).
+			funcMinimal.
 				StatusConditions(
 					apis.Condition{
 						Type:   buildv1alpha1.FunctionConditionImageResolved,
@@ -212,21 +207,21 @@ func TestFunctionReconcile(t *testing.T) {
 		Name: "create kpack image, propagating labels",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.Function(funcValid).
+			funcValid.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.AddLabel(testLabelKey, testLabelValue)
 				}).
 				Get(),
 		},
 		ExpectCreates: []runtime.Object{
-			factories.KpackImage(kpackImageCreate).
+			kpackImageCreate.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.AddLabel(testLabelKey, testLabelValue)
 				}).
 				Get(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.Function(funcMinimal).
+			funcMinimal.
 				StatusConditions(
 					apis.Condition{
 						Type:   buildv1alpha1.FunctionConditionImageResolved,
@@ -249,18 +244,18 @@ func TestFunctionReconcile(t *testing.T) {
 		Name: "default image",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.ConfigMap(cmImagePrefix).
+			cmImagePrefix.
 				AddData("default-image-prefix", testImagePrefix).
 				Get(),
-			factories.Function(funcMinimal).
+			funcMinimal.
 				SourceGit(testGitUrl, testGitRevision).
 				Get(),
 		},
 		ExpectCreates: []runtime.Object{
-			kpackImageCreate,
+			kpackImageCreate.Get(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.Function(funcMinimal).
+			funcMinimal.
 				StatusConditions(
 					apis.Condition{
 						Type:   buildv1alpha1.FunctionConditionImageResolved,
@@ -283,12 +278,12 @@ func TestFunctionReconcile(t *testing.T) {
 		Name: "default image, missing",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.Function(funcMinimal).
+			funcMinimal.
 				SourceGit(testGitUrl, testGitRevision).
 				Get(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.Function(funcMinimal).
+			funcMinimal.
 				StatusConditions(
 					apis.Condition{
 						Type:    buildv1alpha1.FunctionConditionImageResolved,
@@ -314,13 +309,13 @@ func TestFunctionReconcile(t *testing.T) {
 		Name: "default image, undefined",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			cmImagePrefix,
-			factories.Function(funcMinimal).
+			cmImagePrefix.Get(),
+			funcMinimal.
 				SourceGit(testGitUrl, testGitRevision).
 				Get(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.Function(funcMinimal).
+			funcMinimal.
 				StatusConditions(
 					apis.Condition{
 						Type:    buildv1alpha1.FunctionConditionImageResolved,
@@ -349,13 +344,13 @@ func TestFunctionReconcile(t *testing.T) {
 			rtesting.InduceFailure("get", "ConfigMap"),
 		},
 		GivenObjects: []runtime.Object{
-			cmImagePrefix,
-			factories.Function(funcMinimal).
+			cmImagePrefix.Get(),
+			funcMinimal.
 				SourceGit(testGitUrl, testGitRevision).
 				Get(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.Function(funcMinimal).
+			funcMinimal.
 				StatusConditions(
 					apis.Condition{
 						Type:    buildv1alpha1.FunctionConditionImageResolved,
@@ -381,14 +376,14 @@ func TestFunctionReconcile(t *testing.T) {
 		Name: "kpack image ready",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			funcValid,
-			factories.KpackImage(kpackImageGiven).
+			funcValid.Get(),
+			kpackImageGiven.
 				StatusReady().
 				StatusLatestImage("%s/%s@sha256:%s", testImagePrefix, testName, testSha256).
 				Get(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.Function(funcMinimal).
+			funcMinimal.
 				StatusConditions(
 					apis.Condition{
 						Type:   buildv1alpha1.FunctionConditionImageResolved,
@@ -403,7 +398,7 @@ func TestFunctionReconcile(t *testing.T) {
 						Status: corev1.ConditionTrue,
 					},
 				).
-				StatusKpackImageRef(kpackImageGiven.Name).
+				StatusKpackImageRef(kpackImageGiven.Get().Name).
 				StatusTargetImage("%s/%s", testImagePrefix, testName).
 				StatusLatestImage("%s/%s@sha256:%s", testImagePrefix, testName, testSha256).
 				Get(),
@@ -412,15 +407,15 @@ func TestFunctionReconcile(t *testing.T) {
 		Name: "kpack image ready, build cache",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			funcValid,
-			factories.KpackImage(kpackImageGiven).
+			funcValid.Get(),
+			kpackImageGiven.
 				StatusReady().
 				StatusBuildCacheName(testBuildCacheName).
 				StatusLatestImage("%s/%s@sha256:%s", testImagePrefix, testName, testSha256).
 				Get(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.Function(funcMinimal).
+			funcMinimal.
 				StatusConditions(
 					apis.Condition{
 						Type:   buildv1alpha1.FunctionConditionImageResolved,
@@ -435,7 +430,7 @@ func TestFunctionReconcile(t *testing.T) {
 						Status: corev1.ConditionTrue,
 					},
 				).
-				StatusKpackImageRef(kpackImageGiven.Name).
+				StatusKpackImageRef(kpackImageGiven.Get().Name).
 				StatusBuildCacheRef(testBuildCacheName).
 				StatusTargetImage("%s/%s", testImagePrefix, testName).
 				StatusLatestImage("%s/%s@sha256:%s", testImagePrefix, testName, testSha256).
@@ -445,8 +440,8 @@ func TestFunctionReconcile(t *testing.T) {
 		Name: "kpack image not-ready",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			funcValid,
-			factories.KpackImage(kpackImageGiven).
+			funcValid.Get(),
+			kpackImageGiven.
 				StatusConditions(
 					apis.Condition{
 						Type:    apis.ConditionReady,
@@ -459,7 +454,7 @@ func TestFunctionReconcile(t *testing.T) {
 				Get(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.Function(funcMinimal).
+			funcMinimal.
 				StatusConditions(
 					apis.Condition{
 						Type:   buildv1alpha1.FunctionConditionImageResolved,
@@ -478,7 +473,7 @@ func TestFunctionReconcile(t *testing.T) {
 						Message: testConditionMessage,
 					},
 				).
-				StatusKpackImageRef(kpackImageGiven.Name).
+				StatusKpackImageRef(kpackImageGiven.Get().Name).
 				StatusTargetImage("%s/%s", testImagePrefix, testName).
 				StatusLatestImage("%s/%s@sha256:%s", testImagePrefix, testName, testSha256).
 				Get(),
@@ -490,14 +485,14 @@ func TestFunctionReconcile(t *testing.T) {
 			rtesting.InduceFailure("create", "Image"),
 		},
 		GivenObjects: []runtime.Object{
-			funcValid,
+			funcValid.Get(),
 		},
 		ShouldErr: true,
 		ExpectCreates: []runtime.Object{
-			kpackImageCreate,
+			kpackImageCreate.Get(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.Function(funcValid).
+			funcValid.
 				StatusConditions(
 					apis.Condition{
 						Type:   buildv1alpha1.FunctionConditionImageResolved,
@@ -519,16 +514,16 @@ func TestFunctionReconcile(t *testing.T) {
 		Name: "kpack image update, spec",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			funcValid,
-			factories.KpackImage(kpackImageGiven).
+			funcValid.Get(),
+			kpackImageGiven.
 				SourceGit(testGitUrl, "bogus").
 				Get(),
 		},
 		ExpectUpdates: []runtime.Object{
-			kpackImageGiven,
+			kpackImageGiven.Get(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.Function(funcValid).
+			funcValid.
 				StatusConditions(
 					apis.Condition{
 						Type:   buildv1alpha1.FunctionConditionImageResolved,
@@ -543,7 +538,7 @@ func TestFunctionReconcile(t *testing.T) {
 						Status: corev1.ConditionUnknown,
 					},
 				).
-				StatusKpackImageRef(kpackImageGiven.Name).
+				StatusKpackImageRef(kpackImageGiven.Get().Name).
 				StatusTargetImage("%s/%s", testImagePrefix, testName).
 				Get(),
 		},
@@ -551,22 +546,22 @@ func TestFunctionReconcile(t *testing.T) {
 		Name: "kpack image update, labels",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.Function(funcValid).
+			funcValid.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.AddLabel(testLabelKey, testLabelValue)
 				}).
 				Get(),
-			kpackImageGiven,
+			kpackImageGiven.Get(),
 		},
 		ExpectUpdates: []runtime.Object{
-			factories.KpackImage(kpackImageGiven).
+			kpackImageGiven.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.AddLabel(testLabelKey, testLabelValue)
 				}).
 				Get(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.Function(funcValid).
+			funcValid.
 				StatusConditions(
 					apis.Condition{
 						Type:   buildv1alpha1.FunctionConditionImageResolved,
@@ -581,7 +576,7 @@ func TestFunctionReconcile(t *testing.T) {
 						Status: corev1.ConditionUnknown,
 					},
 				).
-				StatusKpackImageRef(kpackImageGiven.Name).
+				StatusKpackImageRef(kpackImageGiven.Get().Name).
 				StatusTargetImage("%s/%s", testImagePrefix, testName).
 				Get(),
 		},
@@ -592,17 +587,17 @@ func TestFunctionReconcile(t *testing.T) {
 			rtesting.InduceFailure("update", "Image"),
 		},
 		GivenObjects: []runtime.Object{
-			funcValid,
-			factories.KpackImage(kpackImageGiven).
+			funcValid.Get(),
+			kpackImageGiven.
 				SourceGit(testGitUrl, "bogus").
 				Get(),
 		},
 		ShouldErr: true,
 		ExpectUpdates: []runtime.Object{
-			kpackImageGiven,
+			kpackImageGiven.Get(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.Function(funcValid).
+			funcValid.
 				StatusConditions(
 					apis.Condition{
 						Type:   buildv1alpha1.FunctionConditionImageResolved,
@@ -627,11 +622,11 @@ func TestFunctionReconcile(t *testing.T) {
 			rtesting.InduceFailure("list", "ImageList"),
 		},
 		GivenObjects: []runtime.Object{
-			funcValid,
+			funcValid.Get(),
 		},
 		ShouldErr: true,
 		ExpectStatusUpdates: []runtime.Object{
-			factories.Function(funcValid).
+			funcValid.
 				StatusConditions(
 					apis.Condition{
 						Type:   buildv1alpha1.FunctionConditionImageResolved,
@@ -656,13 +651,13 @@ func TestFunctionReconcile(t *testing.T) {
 			rtesting.InduceFailure("update", "Function"),
 		},
 		GivenObjects: []runtime.Object{
-			funcValid,
+			funcValid.Get(),
 		},
 		ExpectCreates: []runtime.Object{
-			kpackImageCreate,
+			kpackImageCreate.Get(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.Function(funcMinimal).
+			funcMinimal.
 				StatusConditions(
 					apis.Condition{
 						Type:   buildv1alpha1.FunctionConditionImageResolved,
@@ -686,11 +681,11 @@ func TestFunctionReconcile(t *testing.T) {
 		Name: "delete extra kpack image",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			funcValid,
-			factories.KpackImage(kpackImageGiven).
+			funcValid.Get(),
+			kpackImageGiven.
 				NamespaceName(testNamespace, "extra1").
 				Get(),
-			factories.KpackImage(kpackImageGiven).
+			kpackImageGiven.
 				NamespaceName(testNamespace, "extra2").
 				Get(),
 		},
@@ -699,10 +694,10 @@ func TestFunctionReconcile(t *testing.T) {
 			{Group: "build.pivotal.io", Kind: "Image", Namespace: testNamespace, Name: "extra2"},
 		},
 		ExpectCreates: []runtime.Object{
-			kpackImageCreate,
+			kpackImageCreate.Get(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.Function(funcMinimal).
+			funcMinimal.
 				StatusConditions(
 					apis.Condition{
 						Type:   buildv1alpha1.FunctionConditionImageResolved,
@@ -728,11 +723,11 @@ func TestFunctionReconcile(t *testing.T) {
 			rtesting.InduceFailure("delete", "Image"),
 		},
 		GivenObjects: []runtime.Object{
-			funcValid,
-			factories.KpackImage(kpackImageGiven).
+			funcValid.Get(),
+			kpackImageGiven.
 				NamespaceName(testNamespace, "extra1").
 				Get(),
-			factories.KpackImage(kpackImageGiven).
+			kpackImageGiven.
 				NamespaceName(testNamespace, "extra2").
 				Get(),
 		},
@@ -741,7 +736,7 @@ func TestFunctionReconcile(t *testing.T) {
 			{Group: "build.pivotal.io", Kind: "Image", Namespace: testNamespace, Name: "extra1"},
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.Function(funcMinimal).
+			funcMinimal.
 				StatusConditions(
 					apis.Condition{
 						Type:   buildv1alpha1.FunctionConditionImageResolved,
@@ -763,12 +758,12 @@ func TestFunctionReconcile(t *testing.T) {
 		Name: "local build",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.Function(funcMinimal).
+			funcMinimal.
 				Image("%s/%s", testImagePrefix, testName).
 				Get(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.Function(funcMinimal).
+			funcMinimal.
 				StatusConditions(
 					apis.Condition{
 						Type:   buildv1alpha1.FunctionConditionImageResolved,
@@ -792,16 +787,16 @@ func TestFunctionReconcile(t *testing.T) {
 		Name: "local build, removes existing build",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.Function(funcMinimal).
+			funcMinimal.
 				Image("%s/%s", testImagePrefix, testName).
 				Get(),
-			kpackImageGiven,
+			kpackImageGiven.Get(),
 		},
 		ExpectDeletes: []rtesting.DeleteRef{
-			{Group: "build.pivotal.io", Kind: "Image", Namespace: kpackImageGiven.Namespace, Name: kpackImageGiven.Name},
+			{Group: "build.pivotal.io", Kind: "Image", Namespace: kpackImageGiven.Get().Namespace, Name: kpackImageGiven.Get().Name},
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.Function(funcMinimal).
+			funcMinimal.
 				StatusConditions(
 					apis.Condition{
 						Type:   buildv1alpha1.FunctionConditionImageResolved,
@@ -828,17 +823,17 @@ func TestFunctionReconcile(t *testing.T) {
 			rtesting.InduceFailure("delete", "Image"),
 		},
 		GivenObjects: []runtime.Object{
-			factories.Function(funcMinimal).
+			funcMinimal.
 				Image("%s/%s", testImagePrefix, testName).
 				Get(),
-			kpackImageGiven,
+			kpackImageGiven.Get(),
 		},
 		ShouldErr: true,
 		ExpectDeletes: []rtesting.DeleteRef{
-			{Group: "build.pivotal.io", Kind: "Image", Namespace: kpackImageGiven.Namespace, Name: kpackImageGiven.Name},
+			{Group: "build.pivotal.io", Kind: "Image", Namespace: kpackImageGiven.Get().Namespace, Name: kpackImageGiven.Get().Name},
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.Function(funcMinimal).
+			funcMinimal.
 				StatusConditions(
 					apis.Condition{
 						Type:   buildv1alpha1.FunctionConditionImageResolved,

--- a/pkg/controllers/knative/adapter_controller_test.go
+++ b/pkg/controllers/knative/adapter_controller_test.go
@@ -53,27 +53,21 @@ func TestAdapterReconcile(t *testing.T) {
 	_ = knativeservingv1.AddToScheme(scheme)
 
 	testAdapter := factories.AdapterKnative().
-		NamespaceName(testNamespace, testName).
-		Get()
+		NamespaceName(testNamespace, testName)
 
 	testApplication := factories.Application().
-		NamespaceName(testNamespace, "my-application").
-		Get()
+		NamespaceName(testNamespace, "my-application")
 	testFunction := factories.Function().
-		NamespaceName(testNamespace, "my-function").
-		Get()
+		NamespaceName(testNamespace, "my-function")
 	testContainer := factories.Container().
-		NamespaceName(testNamespace, "my-container").
-		Get()
+		NamespaceName(testNamespace, "my-container")
 
 	testConfiguration := factories.KnativeConfiguration().
 		NamespaceName(testNamespace, "my-configuration").
-		UserContainer(nil).
-		Get()
+		UserContainer(nil)
 	testService := factories.KnativeService().
 		NamespaceName(testNamespace, "my-service").
-		UserContainer(nil).
-		Get()
+		UserContainer(nil)
 
 	table := rtesting.Table{{
 		Name: "adapter does not exist",
@@ -82,7 +76,7 @@ func TestAdapterReconcile(t *testing.T) {
 		Name: "ignore deleted adapter",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
+			testAdapter.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.Deleted(1)
 				}).
@@ -95,7 +89,7 @@ func TestAdapterReconcile(t *testing.T) {
 			rtesting.InduceFailure("get", "Adapter"),
 		},
 		GivenObjects: []runtime.Object{
-			testAdapter,
+			testAdapter.Get(),
 		},
 		ShouldErr: true,
 	}, {
@@ -105,30 +99,30 @@ func TestAdapterReconcile(t *testing.T) {
 			rtesting.InduceFailure("update", "Adapter"),
 		},
 		GivenObjects: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
-				ApplicationRef(testApplication.Name).
-				ServiceRef(testService.Name).
+			testAdapter.
+				ApplicationRef(testApplication.Get().Name).
+				ServiceRef(testService.Get().Name).
 				Get(),
-			factories.Application(testApplication).
+			testApplication.
 				StatusLatestImage(testImage).
 				StatusReady().
 				Get(),
-			testService,
+			testService.Get(),
 		},
 		ShouldErr: true,
 		ExpectTracks: []rtesting.TrackRequest{
-			rtesting.NewTrackRequest(testApplication, testAdapter, scheme),
-			rtesting.NewTrackRequest(testService, testAdapter, scheme),
+			rtesting.NewTrackRequest(testApplication.Get(), testAdapter.Get(), scheme),
+			rtesting.NewTrackRequest(testService.Get(), testAdapter.Get(), scheme),
 		},
 		ExpectUpdates: []runtime.Object{
-			factories.KnativeService(testService).
+			testService.
 				UserContainer(func(uc *corev1.Container) {
 					uc.Image = testImage
 				}).
 				Get(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
+			testAdapter.
 				StatusConditions(
 					apis.Condition{
 						Type:   knativev1alpha1.AdapterConditionBuildReady,
@@ -150,29 +144,29 @@ func TestAdapterReconcile(t *testing.T) {
 		Name: "adapt application to service",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
-				ApplicationRef(testApplication.Name).
-				ServiceRef(testService.Name).
+			testAdapter.
+				ApplicationRef(testApplication.Get().Name).
+				ServiceRef(testService.Get().Name).
 				Get(),
-			factories.Application(testApplication).
+			testApplication.
 				StatusLatestImage(testImage).
 				StatusReady().
 				Get(),
-			testService,
+			testService.Get(),
 		},
 		ExpectTracks: []rtesting.TrackRequest{
-			rtesting.NewTrackRequest(testApplication, testAdapter, scheme),
-			rtesting.NewTrackRequest(testService, testAdapter, scheme),
+			rtesting.NewTrackRequest(testApplication.Get(), testAdapter.Get(), scheme),
+			rtesting.NewTrackRequest(testService.Get(), testAdapter.Get(), scheme),
 		},
 		ExpectUpdates: []runtime.Object{
-			factories.KnativeService(testService).
+			testService.
 				UserContainer(func(uc *corev1.Container) {
 					uc.Image = testImage
 				}).
 				Get(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
+			testAdapter.
 				StatusConditions(
 					apis.Condition{
 						Type:   knativev1alpha1.AdapterConditionBuildReady,
@@ -194,32 +188,32 @@ func TestAdapterReconcile(t *testing.T) {
 		Name: "adapt application to service, application not ready",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
-				ApplicationRef(testApplication.Name).
-				ServiceRef(testService.Name).
+			testAdapter.
+				ApplicationRef(testApplication.Get().Name).
+				ServiceRef(testService.Get().Name).
 				Get(),
-			testApplication,
-			testService,
+			testApplication.Get(),
+			testService.Get(),
 		},
 		ShouldErr: true,
 		ExpectTracks: []rtesting.TrackRequest{
-			rtesting.NewTrackRequest(testApplication, testAdapter, scheme),
+			rtesting.NewTrackRequest(testApplication.Get(), testAdapter.Get(), scheme),
 		},
 	}, {
 		Name: "adapt application to service, application not found",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
-				ApplicationRef(testApplication.Name).
-				ServiceRef(testService.Name).
+			testAdapter.
+				ApplicationRef(testApplication.Get().Name).
+				ServiceRef(testService.Get().Name).
 				Get(),
-			testService,
+			testService.Get(),
 		},
 		ExpectTracks: []rtesting.TrackRequest{
-			rtesting.NewTrackRequest(testApplication, testAdapter, scheme),
+			rtesting.NewTrackRequest(testApplication.Get(), testAdapter.Get(), scheme),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
+			testAdapter.
 				StatusConditions(
 					apis.Condition{
 						Type:   knativev1alpha1.AdapterConditionBuildReady,
@@ -243,47 +237,47 @@ func TestAdapterReconcile(t *testing.T) {
 			rtesting.InduceFailure("get", "Application"),
 		},
 		GivenObjects: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
-				ApplicationRef(testApplication.Name).
-				ServiceRef(testService.Name).
+			testAdapter.
+				ApplicationRef(testApplication.Get().Name).
+				ServiceRef(testService.Get().Name).
 				Get(),
-			factories.Application(testApplication).
+			testApplication.
 				StatusLatestImage(testImage).
 				StatusReady().
 				Get(),
-			testService,
+			testService.Get(),
 		},
 		ShouldErr: true,
 		ExpectTracks: []rtesting.TrackRequest{
-			rtesting.NewTrackRequest(testApplication, testAdapter, scheme),
+			rtesting.NewTrackRequest(testApplication.Get(), testAdapter.Get(), scheme),
 		},
 	}, {
 		Name: "adapt function to service",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
-				FunctionRef(testFunction.Name).
-				ServiceRef(testService.Name).
+			testAdapter.
+				FunctionRef(testFunction.Get().Name).
+				ServiceRef(testService.Get().Name).
 				Get(),
-			factories.Function(testFunction).
+			testFunction.
 				StatusLatestImage(testImage).
 				StatusReady().
 				Get(),
-			testService,
+			testService.Get(),
 		},
 		ExpectTracks: []rtesting.TrackRequest{
-			rtesting.NewTrackRequest(testFunction, testAdapter, scheme),
-			rtesting.NewTrackRequest(testService, testAdapter, scheme),
+			rtesting.NewTrackRequest(testFunction.Get(), testAdapter.Get(), scheme),
+			rtesting.NewTrackRequest(testService.Get(), testAdapter.Get(), scheme),
 		},
 		ExpectUpdates: []runtime.Object{
-			factories.KnativeService(testService).
+			testService.
 				UserContainer(func(uc *corev1.Container) {
 					uc.Image = testImage
 				}).
 				Get(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
+			testAdapter.
 				StatusConditions(
 					apis.Condition{
 						Type:   knativev1alpha1.AdapterConditionBuildReady,
@@ -305,32 +299,32 @@ func TestAdapterReconcile(t *testing.T) {
 		Name: "adapt function to service, function not ready",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
-				FunctionRef(testFunction.Name).
-				ServiceRef(testService.Name).
+			testAdapter.
+				FunctionRef(testFunction.Get().Name).
+				ServiceRef(testService.Get().Name).
 				Get(),
-			testFunction,
-			testService,
+			testFunction.Get(),
+			testService.Get(),
 		},
 		ShouldErr: true,
 		ExpectTracks: []rtesting.TrackRequest{
-			rtesting.NewTrackRequest(testFunction, testAdapter, scheme),
+			rtesting.NewTrackRequest(testFunction.Get(), testAdapter.Get(), scheme),
 		},
 	}, {
 		Name: "adapt function to service, function not found",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
-				FunctionRef(testFunction.Name).
-				ServiceRef(testService.Name).
+			testAdapter.
+				FunctionRef(testFunction.Get().Name).
+				ServiceRef(testService.Get().Name).
 				Get(),
-			testService,
+			testService.Get(),
 		},
 		ExpectTracks: []rtesting.TrackRequest{
-			rtesting.NewTrackRequest(testFunction, testAdapter, scheme),
+			rtesting.NewTrackRequest(testFunction.Get(), testAdapter.Get(), scheme),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
+			testAdapter.
 				StatusConditions(
 					apis.Condition{
 						Type:   knativev1alpha1.AdapterConditionBuildReady,
@@ -354,47 +348,47 @@ func TestAdapterReconcile(t *testing.T) {
 			rtesting.InduceFailure("get", "function"),
 		},
 		GivenObjects: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
-				FunctionRef(testFunction.Name).
-				ServiceRef(testService.Name).
+			testAdapter.
+				FunctionRef(testFunction.Get().Name).
+				ServiceRef(testService.Get().Name).
 				Get(),
-			factories.Function(testFunction).
+			testFunction.
 				StatusLatestImage(testImage).
 				StatusReady().
 				Get(),
-			testService,
+			testService.Get(),
 		},
 		ShouldErr: true,
 		ExpectTracks: []rtesting.TrackRequest{
-			rtesting.NewTrackRequest(testFunction, testAdapter, scheme),
+			rtesting.NewTrackRequest(testFunction.Get(), testAdapter.Get(), scheme),
 		},
 	}, {
 		Name: "adapt container to service",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
-				ContainerRef(testContainer.Name).
-				ServiceRef(testService.Name).
+			testAdapter.
+				ContainerRef(testContainer.Get().Name).
+				ServiceRef(testService.Get().Name).
 				Get(),
-			factories.Container(testContainer).
+			testContainer.
 				StatusLatestImage(testImage).
 				StatusReady().
 				Get(),
-			testService,
+			testService.Get(),
 		},
 		ExpectTracks: []rtesting.TrackRequest{
-			rtesting.NewTrackRequest(testContainer, testAdapter, scheme),
-			rtesting.NewTrackRequest(testService, testAdapter, scheme),
+			rtesting.NewTrackRequest(testContainer.Get(), testAdapter.Get(), scheme),
+			rtesting.NewTrackRequest(testService.Get(), testAdapter.Get(), scheme),
 		},
 		ExpectUpdates: []runtime.Object{
-			factories.KnativeService(testService).
+			testService.
 				UserContainer(func(uc *corev1.Container) {
 					uc.Image = testImage
 				}).
 				Get(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
+			testAdapter.
 				StatusConditions(
 					apis.Condition{
 						Type:   knativev1alpha1.AdapterConditionBuildReady,
@@ -416,32 +410,32 @@ func TestAdapterReconcile(t *testing.T) {
 		Name: "adapt container to service, container not ready",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
-				ContainerRef(testContainer.Name).
-				ServiceRef(testService.Name).
+			testAdapter.
+				ContainerRef(testContainer.Get().Name).
+				ServiceRef(testService.Get().Name).
 				Get(),
-			testContainer,
-			testService,
+			testContainer.Get(),
+			testService.Get(),
 		},
 		ShouldErr: true,
 		ExpectTracks: []rtesting.TrackRequest{
-			rtesting.NewTrackRequest(testContainer, testAdapter, scheme),
+			rtesting.NewTrackRequest(testContainer.Get(), testAdapter.Get(), scheme),
 		},
 	}, {
 		Name: "adapt container to service, container not found",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
-				ContainerRef(testContainer.Name).
-				ServiceRef(testService.Name).
+			testAdapter.
+				ContainerRef(testContainer.Get().Name).
+				ServiceRef(testService.Get().Name).
 				Get(),
-			testService,
+			testService.Get(),
 		},
 		ExpectTracks: []rtesting.TrackRequest{
-			rtesting.NewTrackRequest(testContainer, testAdapter, scheme),
+			rtesting.NewTrackRequest(testContainer.Get(), testAdapter.Get(), scheme),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
+			testAdapter.
 				StatusConditions(
 					apis.Condition{
 						Type:   knativev1alpha1.AdapterConditionBuildReady,
@@ -465,39 +459,39 @@ func TestAdapterReconcile(t *testing.T) {
 			rtesting.InduceFailure("get", "Container"),
 		},
 		GivenObjects: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
-				ContainerRef(testContainer.Name).
-				ServiceRef(testService.Name).
+			testAdapter.
+				ContainerRef(testContainer.Get().Name).
+				ServiceRef(testService.Get().Name).
 				Get(),
-			factories.Container(testContainer).
+			testContainer.
 				StatusLatestImage(testImage).
 				StatusReady().
 				Get(),
-			testService,
+			testService.Get(),
 		},
 		ShouldErr: true,
 		ExpectTracks: []rtesting.TrackRequest{
-			rtesting.NewTrackRequest(testContainer, testAdapter, scheme),
+			rtesting.NewTrackRequest(testContainer.Get(), testAdapter.Get(), scheme),
 		},
 	}, {
 		Name: "adapt container to service, service not found",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
-				ContainerRef(testContainer.Name).
-				ServiceRef(testService.Name).
+			testAdapter.
+				ContainerRef(testContainer.Get().Name).
+				ServiceRef(testService.Get().Name).
 				Get(),
-			factories.Container(testContainer).
+			testContainer.
 				StatusLatestImage(testImage).
 				StatusReady().
 				Get(),
 		},
 		ExpectTracks: []rtesting.TrackRequest{
-			rtesting.NewTrackRequest(testContainer, testAdapter, scheme),
-			rtesting.NewTrackRequest(testService, testAdapter, scheme),
+			rtesting.NewTrackRequest(testContainer.Get(), testAdapter.Get(), scheme),
+			rtesting.NewTrackRequest(testService.Get(), testAdapter.Get(), scheme),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
+			testAdapter.
 				StatusConditions(
 					apis.Condition{
 						Type:   knativev1alpha1.AdapterConditionBuildReady,
@@ -526,28 +520,28 @@ func TestAdapterReconcile(t *testing.T) {
 			rtesting.InduceFailure("get", "Service"),
 		},
 		GivenObjects: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
-				ContainerRef(testContainer.Name).
-				ServiceRef(testService.Name).
+			testAdapter.
+				ContainerRef(testContainer.Get().Name).
+				ServiceRef(testService.Get().Name).
 				Get(),
-			factories.Container(testContainer).
+			testContainer.
 				StatusLatestImage(testImage).
 				StatusReady().
 				Get(),
-			testService,
+			testService.Get(),
 		},
 		ShouldErr: true,
 		ExpectTracks: []rtesting.TrackRequest{
-			rtesting.NewTrackRequest(testContainer, testAdapter, scheme),
-			rtesting.NewTrackRequest(testService, testAdapter, scheme),
+			rtesting.NewTrackRequest(testContainer.Get(), testAdapter.Get(), scheme),
+			rtesting.NewTrackRequest(testService.Get(), testAdapter.Get(), scheme),
 		},
 	}, {
 		Name: "adapt container to service, service is up to date",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
-				ContainerRef(testContainer.Name).
-				ServiceRef(testService.Name).
+			testAdapter.
+				ContainerRef(testContainer.Get().Name).
+				ServiceRef(testService.Get().Name).
 				StatusConditions(
 					apis.Condition{
 						Type:   knativev1alpha1.AdapterConditionBuildReady,
@@ -564,19 +558,19 @@ func TestAdapterReconcile(t *testing.T) {
 				).
 				StatusLatestImage(testImage).
 				Get(),
-			factories.Container(testContainer).
+			testContainer.
 				StatusLatestImage(testImage).
 				StatusReady().
 				Get(),
-			factories.KnativeService(testService).
+			testService.
 				UserContainer(func(uc *corev1.Container) {
 					uc.Image = testImage
 				}).
 				Get(),
 		},
 		ExpectTracks: []rtesting.TrackRequest{
-			rtesting.NewTrackRequest(testContainer, testAdapter, scheme),
-			rtesting.NewTrackRequest(testService, testAdapter, scheme),
+			rtesting.NewTrackRequest(testContainer.Get(), testAdapter.Get(), scheme),
+			rtesting.NewTrackRequest(testService.Get(), testAdapter.Get(), scheme),
 		},
 	}, {
 		Name: "adapt container to service, update service failed",
@@ -585,23 +579,23 @@ func TestAdapterReconcile(t *testing.T) {
 			rtesting.InduceFailure("update", "Service"),
 		},
 		GivenObjects: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
-				ContainerRef(testContainer.Name).
-				ServiceRef(testService.Name).
+			testAdapter.
+				ContainerRef(testContainer.Get().Name).
+				ServiceRef(testService.Get().Name).
 				Get(),
-			factories.Container(testContainer).
+			testContainer.
 				StatusLatestImage(testImage).
 				StatusReady().
 				Get(),
-			testService,
+			testService.Get(),
 		},
 		ShouldErr: true,
 		ExpectTracks: []rtesting.TrackRequest{
-			rtesting.NewTrackRequest(testContainer, testAdapter, scheme),
-			rtesting.NewTrackRequest(testService, testAdapter, scheme),
+			rtesting.NewTrackRequest(testContainer.Get(), testAdapter.Get(), scheme),
+			rtesting.NewTrackRequest(testService.Get(), testAdapter.Get(), scheme),
 		},
 		ExpectUpdates: []runtime.Object{
-			factories.KnativeService(testService).
+			testService.
 				UserContainer(func(uc *corev1.Container) {
 					uc.Image = testImage
 				}).
@@ -611,29 +605,29 @@ func TestAdapterReconcile(t *testing.T) {
 		Name: "adapt container to configuration",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
-				ContainerRef(testContainer.Name).
-				ConfigurationRef(testConfiguration.Name).
+			testAdapter.
+				ContainerRef(testContainer.Get().Name).
+				ConfigurationRef(testConfiguration.Get().Name).
 				Get(),
-			factories.Container(testContainer).
+			testContainer.
 				StatusLatestImage(testImage).
 				StatusReady().
 				Get(),
-			testConfiguration,
+			testConfiguration.Get(),
 		},
 		ExpectTracks: []rtesting.TrackRequest{
-			rtesting.NewTrackRequest(testContainer, testAdapter, scheme),
-			rtesting.NewTrackRequest(testConfiguration, testAdapter, scheme),
+			rtesting.NewTrackRequest(testContainer.Get(), testAdapter.Get(), scheme),
+			rtesting.NewTrackRequest(testConfiguration.Get(), testAdapter.Get(), scheme),
 		},
 		ExpectUpdates: []runtime.Object{
-			factories.KnativeConfiguration(testConfiguration).
+			testConfiguration.
 				UserContainer(func(uc *corev1.Container) {
 					uc.Image = testImage
 				}).
 				Get(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
+			testAdapter.
 				StatusConditions(
 					apis.Condition{
 						Type:   knativev1alpha1.AdapterConditionBuildReady,
@@ -655,21 +649,21 @@ func TestAdapterReconcile(t *testing.T) {
 		Name: "adapt container to configuration, configuration not found",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
-				ContainerRef(testContainer.Name).
-				ConfigurationRef(testConfiguration.Name).
+			testAdapter.
+				ContainerRef(testContainer.Get().Name).
+				ConfigurationRef(testConfiguration.Get().Name).
 				Get(),
-			factories.Container(testContainer).
+			testContainer.
 				StatusLatestImage(testImage).
 				StatusReady().
 				Get(),
 		},
 		ExpectTracks: []rtesting.TrackRequest{
-			rtesting.NewTrackRequest(testContainer, testAdapter, scheme),
-			rtesting.NewTrackRequest(testConfiguration, testAdapter, scheme),
+			rtesting.NewTrackRequest(testContainer.Get(), testAdapter.Get(), scheme),
+			rtesting.NewTrackRequest(testConfiguration.Get(), testAdapter.Get(), scheme),
 		},
 		ExpectStatusUpdates: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
+			testAdapter.
 				StatusConditions(
 					apis.Condition{
 						Type:   knativev1alpha1.AdapterConditionBuildReady,
@@ -698,28 +692,28 @@ func TestAdapterReconcile(t *testing.T) {
 			rtesting.InduceFailure("get", "Configuration"),
 		},
 		GivenObjects: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
-				ContainerRef(testContainer.Name).
-				ConfigurationRef(testConfiguration.Name).
+			testAdapter.
+				ContainerRef(testContainer.Get().Name).
+				ConfigurationRef(testConfiguration.Get().Name).
 				Get(),
-			factories.Container(testContainer).
+			testContainer.
 				StatusLatestImage(testImage).
 				StatusReady().
 				Get(),
-			testConfiguration,
+			testConfiguration.Get(),
 		},
 		ShouldErr: true,
 		ExpectTracks: []rtesting.TrackRequest{
-			rtesting.NewTrackRequest(testContainer, testAdapter, scheme),
-			rtesting.NewTrackRequest(testConfiguration, testAdapter, scheme),
+			rtesting.NewTrackRequest(testContainer.Get(), testAdapter.Get(), scheme),
+			rtesting.NewTrackRequest(testConfiguration.Get(), testAdapter.Get(), scheme),
 		},
 	}, {
 		Name: "adapt container to configuration, configuration is up to date",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
-				ContainerRef(testContainer.Name).
-				ConfigurationRef(testConfiguration.Name).
+			testAdapter.
+				ContainerRef(testContainer.Get().Name).
+				ConfigurationRef(testConfiguration.Get().Name).
 				StatusConditions(
 					apis.Condition{
 						Type:   knativev1alpha1.AdapterConditionBuildReady,
@@ -736,19 +730,19 @@ func TestAdapterReconcile(t *testing.T) {
 				).
 				StatusLatestImage(testImage).
 				Get(),
-			factories.Container(testContainer).
+			testContainer.
 				StatusLatestImage(testImage).
 				StatusReady().
 				Get(),
-			factories.KnativeConfiguration(testConfiguration).
+			testConfiguration.
 				UserContainer(func(uc *corev1.Container) {
 					uc.Image = testImage
 				}).
 				Get(),
 		},
 		ExpectTracks: []rtesting.TrackRequest{
-			rtesting.NewTrackRequest(testContainer, testAdapter, scheme),
-			rtesting.NewTrackRequest(testConfiguration, testAdapter, scheme),
+			rtesting.NewTrackRequest(testContainer.Get(), testAdapter.Get(), scheme),
+			rtesting.NewTrackRequest(testConfiguration.Get(), testAdapter.Get(), scheme),
 		},
 	}, {
 		Name: "adapt container to configuration, update configuration failed",
@@ -757,23 +751,23 @@ func TestAdapterReconcile(t *testing.T) {
 			rtesting.InduceFailure("update", "Configuration"),
 		},
 		GivenObjects: []runtime.Object{
-			factories.AdapterKnative(testAdapter).
-				ContainerRef(testContainer.Name).
-				ConfigurationRef(testConfiguration.Name).
+			testAdapter.
+				ContainerRef(testContainer.Get().Name).
+				ConfigurationRef(testConfiguration.Get().Name).
 				Get(),
-			factories.Container(testContainer).
+			testContainer.
 				StatusLatestImage(testImage).
 				StatusReady().
 				Get(),
-			testConfiguration,
+			testConfiguration.Get(),
 		},
 		ShouldErr: true,
 		ExpectTracks: []rtesting.TrackRequest{
-			rtesting.NewTrackRequest(testContainer, testAdapter, scheme),
-			rtesting.NewTrackRequest(testConfiguration, testAdapter, scheme),
+			rtesting.NewTrackRequest(testContainer.Get(), testAdapter.Get(), scheme),
+			rtesting.NewTrackRequest(testConfiguration.Get(), testAdapter.Get(), scheme),
 		},
 		ExpectUpdates: []runtime.Object{
-			factories.KnativeConfiguration(testConfiguration).
+			testConfiguration.
 				UserContainer(func(uc *corev1.Container) {
 					uc.Image = testImage
 				}).


### PR DESCRIPTION
This makes it easier to extend stubs as they no longer need to be
reinstated within a factory. The trade off is that actual object needs
to be gotten when used.