### PR TITLE
[Spike] Use factories instead of Kubernetes objects in test table rows

### DIFF
--- a/pkg/controllers/build/clusterbuilder_controller_test.go
+++ b/pkg/controllers/build/clusterbuilder_controller_test.go
@@ -63,72 +63,67 @@ func TestClusterBuildersReconciler(t *testing.T) {
 	table := rtesting.Table{{
 		Name: "builders configmap does not exist",
 		Key:  testKey,
-		ExpectCreates: []runtime.Object{
-			testBuilders.Get(),
+		ExpectCreates: []rtesting.Factory{
+			testBuilders,
 		},
 	}, {
 		Name: "builders configmap unchanged",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
-			testBuilders.Get(),
+		GivenObjects: []rtesting.Factory{
+			testBuilders,
 		},
 	}, {
 		Name: "ignore deleted builders configmap",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
+		GivenObjects: []rtesting.Factory{
 			testBuilders.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.Deleted(1)
-				}).
-				Get(),
-			testApplicationBuilder.Get(),
-			testFunctionBuilder.Get(),
+				}),
+			testApplicationBuilder,
+			testFunctionBuilder,
 		},
 	}, {
 		Name: "ignore other configmaps in the correct namespace",
 		Key:  types.NamespacedName{Namespace: testNamespace, Name: "not-builders"},
-		GivenObjects: []runtime.Object{
+		GivenObjects: []rtesting.Factory{
 			testBuilders.
-				NamespaceName(testNamespace, "not-builders").
-				Get(),
-			testApplicationBuilder.Get(),
-			testFunctionBuilder.Get(),
+				NamespaceName(testNamespace, "not-builders"),
+			testApplicationBuilder,
+			testFunctionBuilder,
 		},
 	}, {
 		Name: "ignore other configmaps in the wrong namespace",
 		Key:  types.NamespacedName{Namespace: "not-riff-system", Name: testName},
-		GivenObjects: []runtime.Object{
+		GivenObjects: []rtesting.Factory{
 			testBuilders.
-				NamespaceName("not-riff-system", testName).
-				Get(),
-			testApplicationBuilder.Get(),
-			testFunctionBuilder.Get(),
+				NamespaceName("not-riff-system", testName),
+			testApplicationBuilder,
+			testFunctionBuilder,
 		},
 	}, {
 		Name: "create builders configmap, not ready",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
-			testApplicationBuilder.Get(),
-			testFunctionBuilder.Get(),
+		GivenObjects: []rtesting.Factory{
+			testApplicationBuilder,
+			testFunctionBuilder,
 		},
-		ExpectCreates: []runtime.Object{
+		ExpectCreates: []rtesting.Factory{
 			testBuilders.
 				AddData("riff-application", "").
-				AddData("riff-function", "").
-				Get(),
+				AddData("riff-function", ""),
 		},
 	}, {
 		Name: "create builders configmap, ready",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
-			testApplicationBuilderReady.Get(),
-			testFunctionBuilderReady.Get(),
+		GivenObjects: []rtesting.Factory{
+			testApplicationBuilderReady,
+			testFunctionBuilderReady,
 		},
-		ExpectCreates: []runtime.Object{
+		ExpectCreates: []rtesting.Factory{
 			testBuilders.
 				AddData("riff-application", testApplicationImage).
-				AddData("riff-function", testFunctionImage).
-				Get(),
+				AddData("riff-function", testFunctionImage),
 		},
 	}, {
 		Name: "create builders configmap, error",
@@ -136,30 +131,28 @@ func TestClusterBuildersReconciler(t *testing.T) {
 		WithReactors: []rtesting.ReactionFunc{
 			rtesting.InduceFailure("create", "ConfigMap"),
 		},
-		GivenObjects: []runtime.Object{
-			testApplicationBuilder.Get(),
-			testFunctionBuilder.Get(),
+		GivenObjects: []rtesting.Factory{
+			testApplicationBuilder,
+			testFunctionBuilder,
 		},
 		ShouldErr: true,
-		ExpectCreates: []runtime.Object{
+		ExpectCreates: []rtesting.Factory{
 			testBuilders.
 				AddData("riff-application", "").
-				AddData("riff-function", "").
-				Get(),
+				AddData("riff-function", ""),
 		},
 	}, {
 		Name: "update builders configmap",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
-			testBuilders.Get(),
-			testApplicationBuilderReady.Get(),
-			testFunctionBuilderReady.Get(),
+		GivenObjects: []rtesting.Factory{
+			testBuilders,
+			testApplicationBuilderReady,
+			testFunctionBuilderReady,
 		},
-		ExpectUpdates: []runtime.Object{
+		ExpectUpdates: []rtesting.Factory{
 			testBuilders.
 				AddData("riff-application", testApplicationImage).
-				AddData("riff-function", testFunctionImage).
-				Get(),
+				AddData("riff-function", testFunctionImage),
 		},
 	}, {
 		Name: "update builders configmap, error",
@@ -167,17 +160,16 @@ func TestClusterBuildersReconciler(t *testing.T) {
 		WithReactors: []rtesting.ReactionFunc{
 			rtesting.InduceFailure("update", "ConfigMap"),
 		},
-		GivenObjects: []runtime.Object{
-			testBuilders.Get(),
-			testApplicationBuilderReady.Get(),
-			testFunctionBuilderReady.Get(),
+		GivenObjects: []rtesting.Factory{
+			testBuilders,
+			testApplicationBuilderReady,
+			testFunctionBuilderReady,
 		},
 		ShouldErr: true,
-		ExpectUpdates: []runtime.Object{
+		ExpectUpdates: []rtesting.Factory{
 			testBuilders.
 				AddData("riff-application", testApplicationImage).
-				AddData("riff-function", testFunctionImage).
-				Get(),
+				AddData("riff-function", testFunctionImage),
 		},
 	}, {
 		Name: "get builders configmap error",
@@ -185,10 +177,10 @@ func TestClusterBuildersReconciler(t *testing.T) {
 		WithReactors: []rtesting.ReactionFunc{
 			rtesting.InduceFailure("get", "ConfigMap"),
 		},
-		GivenObjects: []runtime.Object{
-			testBuilders.Get(),
-			testApplicationBuilder.Get(),
-			testFunctionBuilder.Get(),
+		GivenObjects: []rtesting.Factory{
+			testBuilders,
+			testApplicationBuilder,
+			testFunctionBuilder,
 		},
 		ShouldErr: true,
 	}, {
@@ -197,10 +189,10 @@ func TestClusterBuildersReconciler(t *testing.T) {
 		WithReactors: []rtesting.ReactionFunc{
 			rtesting.InduceFailure("list", "ClusterBuilderList"),
 		},
-		GivenObjects: []runtime.Object{
-			testBuilders.Get(),
-			testApplicationBuilder.Get(),
-			testFunctionBuilder.Get(),
+		GivenObjects: []rtesting.Factory{
+			testBuilders,
+			testApplicationBuilder,
+			testFunctionBuilder,
 		},
 		ShouldErr: true,
 	}}

--- a/pkg/controllers/build/credential_controller_test.go
+++ b/pkg/controllers/build/credential_controller_test.go
@@ -63,20 +63,18 @@ func TestCredentialsReconciler(t *testing.T) {
 	}, {
 		Name: "ignore deleted service account",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
+		GivenObjects: []rtesting.Factory{
 			testServiceAccount.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.Deleted(1)
-				}).
-				Get(),
+				}),
 		},
 	}, {
 		Name: "ignore non-build service accounts",
 		Key:  types.NamespacedName{Namespace: testNamespace, Name: "not-riff-build"},
-		GivenObjects: []runtime.Object{
+		GivenObjects: []rtesting.Factory{
 			testServiceAccount.
-				NamespaceName(testNamespace, "not-riff-build").
-				Get(),
+				NamespaceName(testNamespace, "not-riff-build"),
 		},
 	}, {
 		Name: "error fetching service account",
@@ -84,22 +82,21 @@ func TestCredentialsReconciler(t *testing.T) {
 		WithReactors: []rtesting.ReactionFunc{
 			rtesting.InduceFailure("get", "ServiceAccount"),
 		},
-		GivenObjects: []runtime.Object{
-			testServiceAccount.Get(),
+		GivenObjects: []rtesting.Factory{
+			testServiceAccount,
 		},
 		ShouldErr: true,
 	}, {
 		Name: "create service account for application",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
-			testApplication.Get(),
+		GivenObjects: []rtesting.Factory{
+			testApplication,
 		},
-		ExpectCreates: []runtime.Object{
+		ExpectCreates: []rtesting.Factory{
 			testServiceAccount.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.AddAnnotation("build.projectriff.io/credentials", "")
-				}).
-				Get(),
+				}),
 		},
 	}, {
 		Name: "create service account for application, listing fail",
@@ -107,22 +104,21 @@ func TestCredentialsReconciler(t *testing.T) {
 		WithReactors: []rtesting.ReactionFunc{
 			rtesting.InduceFailure("list", "ApplicationList"),
 		},
-		GivenObjects: []runtime.Object{
-			testApplication.Get(),
+		GivenObjects: []rtesting.Factory{
+			testApplication,
 		},
 		ShouldErr: true,
 	}, {
 		Name: "create service account for function",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
-			testFunction.Get(),
+		GivenObjects: []rtesting.Factory{
+			testFunction,
 		},
-		ExpectCreates: []runtime.Object{
+		ExpectCreates: []rtesting.Factory{
 			testServiceAccount.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.AddAnnotation("build.projectriff.io/credentials", "")
-				}).
-				Get(),
+				}),
 		},
 	}, {
 		Name: "create service account for function, listing fail",
@@ -130,22 +126,21 @@ func TestCredentialsReconciler(t *testing.T) {
 		WithReactors: []rtesting.ReactionFunc{
 			rtesting.InduceFailure("list", "FunctionList"),
 		},
-		GivenObjects: []runtime.Object{
-			testFunction.Get(),
+		GivenObjects: []rtesting.Factory{
+			testFunction,
 		},
 		ShouldErr: true,
 	}, {
 		Name: "create service account for container",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
-			testContainer.Get(),
+		GivenObjects: []rtesting.Factory{
+			testContainer,
 		},
-		ExpectCreates: []runtime.Object{
+		ExpectCreates: []rtesting.Factory{
 			testServiceAccount.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.AddAnnotation("build.projectriff.io/credentials", "")
-				}).
-				Get(),
+				}),
 		},
 	}, {
 		Name: "create service account for container, listing fail",
@@ -153,23 +148,22 @@ func TestCredentialsReconciler(t *testing.T) {
 		WithReactors: []rtesting.ReactionFunc{
 			rtesting.InduceFailure("list", "ContainerList"),
 		},
-		GivenObjects: []runtime.Object{
-			testContainer.Get(),
+		GivenObjects: []rtesting.Factory{
+			testContainer,
 		},
 		ShouldErr: true,
 	}, {
 		Name: "create service account for credential",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
-			testCredential.Get(),
+		GivenObjects: []rtesting.Factory{
+			testCredential,
 		},
-		ExpectCreates: []runtime.Object{
+		ExpectCreates: []rtesting.Factory{
 			testServiceAccount.
 				ObjectMeta(func(om factories.ObjectMeta) {
-					om.AddAnnotation("build.projectriff.io/credentials", testCredential.Get().Name)
+					om.AddAnnotation("build.projectriff.io/credentials", testCredential.Get().GetName())
 				}).
-				Secrets(testCredential.Get().Name).
-				Get(),
+				Secrets(testCredential.Get().GetName()),
 		},
 	}, {
 		Name: "create service account for credential, listing fail",
@@ -177,8 +171,8 @@ func TestCredentialsReconciler(t *testing.T) {
 		WithReactors: []rtesting.ReactionFunc{
 			rtesting.InduceFailure("list", "SecretList"),
 		},
-		GivenObjects: []runtime.Object{
-			testCredential.Get(),
+		GivenObjects: []rtesting.Factory{
+			testCredential,
 		},
 		ShouldErr: true,
 	}, {
@@ -187,52 +181,47 @@ func TestCredentialsReconciler(t *testing.T) {
 		WithReactors: []rtesting.ReactionFunc{
 			rtesting.InduceFailure("create", "ServiceAccount"),
 		},
-		GivenObjects: []runtime.Object{
-			testCredential.Get(),
+		GivenObjects: []rtesting.Factory{
+			testCredential,
 		},
 		ShouldErr: true,
-		ExpectCreates: []runtime.Object{
+		ExpectCreates: []rtesting.Factory{
 			testServiceAccount.
 				ObjectMeta(func(om factories.ObjectMeta) {
-					om.AddAnnotation("build.projectriff.io/credentials", testCredential.Get().Name)
+					om.AddAnnotation("build.projectriff.io/credentials", testCredential.Get().GetName())
 				}).
-				Secrets(testCredential.Get().Name).
-				Get(),
+				Secrets(testCredential.Get().GetName()),
 		},
 	}, {
 		Name: "add credential to service account",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
-			testServiceAccount.Get(),
-			testCredential.Get(),
+		GivenObjects: []rtesting.Factory{
+			testServiceAccount,
+			testCredential,
 		},
-		ExpectUpdates: []runtime.Object{
+		ExpectUpdates: []rtesting.Factory{
 			testServiceAccount.
 				ObjectMeta(func(om factories.ObjectMeta) {
-					om.AddAnnotation("build.projectriff.io/credentials", testCredential.Get().Name)
+					om.AddAnnotation("build.projectriff.io/credentials", testCredential.Get().GetName())
 				}).
-				Secrets(testCredential.Get().Name).
-				Get(),
+				Secrets(testCredential.Get().GetName()),
 		},
 	}, {
 		Name: "add credentials to service account",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
-			testServiceAccount.Get(),
+		GivenObjects: []rtesting.Factory{
+			testServiceAccount,
 			testCredential.
-				NamespaceName(testNamespace, "cred-1").
-				Get(),
+				NamespaceName(testNamespace, "cred-1"),
 			testCredential.
-				NamespaceName(testNamespace, "cred-2").
-				Get(),
+				NamespaceName(testNamespace, "cred-2"),
 		},
-		ExpectUpdates: []runtime.Object{
+		ExpectUpdates: []rtesting.Factory{
 			testServiceAccount.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.AddAnnotation("build.projectriff.io/credentials", "cred-1,cred-2")
 				}).
-				Secrets("cred-1", "cred-2").
-				Get(),
+				Secrets("cred-1", "cred-2"),
 		},
 	}, {
 		Name: "add credential to service account, list credentials error",
@@ -240,9 +229,9 @@ func TestCredentialsReconciler(t *testing.T) {
 		WithReactors: []rtesting.ReactionFunc{
 			rtesting.InduceFailure("list", "SecretList"),
 		},
-		GivenObjects: []runtime.Object{
-			testServiceAccount.Get(),
-			testCredential.Get(),
+		GivenObjects: []rtesting.Factory{
+			testServiceAccount,
+			testCredential,
 		},
 		ShouldErr: true,
 	}, {
@@ -251,92 +240,81 @@ func TestCredentialsReconciler(t *testing.T) {
 		WithReactors: []rtesting.ReactionFunc{
 			rtesting.InduceFailure("update", "ServiceAccount"),
 		},
-		GivenObjects: []runtime.Object{
-			testServiceAccount.Get(),
-			testCredential.Get(),
+		GivenObjects: []rtesting.Factory{
+			testServiceAccount,
+			testCredential,
 		},
 		ShouldErr: true,
-		ExpectUpdates: []runtime.Object{
+		ExpectUpdates: []rtesting.Factory{
 			testServiceAccount.
 				ObjectMeta(func(om factories.ObjectMeta) {
-					om.AddAnnotation("build.projectriff.io/credentials", testCredential.Get().Name)
+					om.AddAnnotation("build.projectriff.io/credentials", testCredential.Get().GetName())
 				}).
-				Secrets(testCredential.Get().Name).
-				Get(),
+				Secrets(testCredential.Get().GetName()),
 		},
 	}, {
 		Name: "add credentials to service account, preserving non-credential bound secrets",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
+		GivenObjects: []rtesting.Factory{
 			testServiceAccount.
-				Secrets("keep-me").
-				Get(),
+				Secrets("keep-me"),
 			testCredential.
-				NamespaceName(testNamespace, "cred-1").
-				Get(),
+				NamespaceName(testNamespace, "cred-1"),
 			testCredential.
-				NamespaceName(testNamespace, "cred-2").
-				Get(),
+				NamespaceName(testNamespace, "cred-2"),
 		},
-		ExpectUpdates: []runtime.Object{
+		ExpectUpdates: []rtesting.Factory{
 			testServiceAccount.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.AddAnnotation("build.projectriff.io/credentials", "cred-1,cred-2")
 				}).
-				Secrets("keep-me", "cred-1", "cred-2").
-				Get(),
+				Secrets("keep-me", "cred-1", "cred-2"),
 		},
 	}, {
 		Name: "ignore non-credential secrets for service account",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
+		GivenObjects: []rtesting.Factory{
 			testServiceAccount.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.AddAnnotation("build.projectriff.io/credentials", "")
 				}).
-				Secrets().
-				Get(),
+				Secrets(),
 			factories.Secret().
-				NamespaceName(testNamespace, "not-a-credential").
-				Get(),
+				NamespaceName(testNamespace, "not-a-credential"),
 		},
 	}, {
 		Name: "remove credential from service account",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
+		GivenObjects: []rtesting.Factory{
 			testServiceAccount.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.AddAnnotation("build.projectriff.io/credentials", "cred-1,cred-2")
 				}).
-				Secrets("cred-1", "cred-2").
-				Get(),
+				Secrets("cred-1", "cred-2"),
 		},
-		ExpectUpdates: []runtime.Object{
+		ExpectUpdates: []rtesting.Factory{
 			testServiceAccount.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.AddAnnotation("build.projectriff.io/credentials", "")
 				}).
-				Secrets().
-				Get(),
+				Secrets(),
 		},
 	}, {
 		Name: "remove credential from service account, preserving non-credential bound secrets",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
+		GivenObjects: []rtesting.Factory{
 			testServiceAccount.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.AddAnnotation("build.projectriff.io/credentials", "cred-1,cred-2")
 				}).
-				Secrets("keep-me", "cred-1", "cred-2").
-				Get(),
+				Secrets("keep-me", "cred-1", "cred-2"),
 		},
-		ExpectUpdates: []runtime.Object{
+		ExpectUpdates: []rtesting.Factory{
 			testServiceAccount.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.AddAnnotation("build.projectriff.io/credentials", "")
 				}).
-				Secrets("keep-me").
-				Get(),
+				Secrets("keep-me"),
 		},
 	}}
 

--- a/pkg/controllers/build/function_controller_test.go
+++ b/pkg/controllers/build/function_controller_test.go
@@ -72,7 +72,7 @@ func TestFunctionReconciler(t *testing.T) {
 			om.Namespace(testNamespace).
 				GenerateName("%s-function-", testName).
 				AddLabel(buildv1alpha1.FunctionLabelKey, testName).
-				ControlledBy(funcMinimal.Get(), scheme)
+				ControlledBy(funcMinimal, scheme)
 		}).
 		Tag("%s/%s", testImagePrefix, testName).
 		FunctionBuilder("", "", "").
@@ -95,12 +95,11 @@ func TestFunctionReconciler(t *testing.T) {
 	}, {
 		Name: "ignore deleted function",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
+		GivenObjects: []rtesting.Factory{
 			funcValid.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.Deleted(1)
-				}).
-				Get(),
+				}),
 		},
 	}, {
 		Name: "function get error",
@@ -112,13 +111,13 @@ func TestFunctionReconciler(t *testing.T) {
 	}, {
 		Name: "create kpack image",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
-			funcValid.Get(),
+		GivenObjects: []rtesting.Factory{
+			funcValid,
 		},
-		ExpectCreates: []runtime.Object{
-			kpackImageCreate.Get(),
+		ExpectCreates: []rtesting.Factory{
+			kpackImageCreate,
 		},
-		ExpectStatusUpdates: []runtime.Object{
+		ExpectStatusUpdates: []rtesting.Factory{
 			funcMinimal.
 				StatusConditions(
 					functionConditionImageResolved.True(),
@@ -126,25 +125,22 @@ func TestFunctionReconciler(t *testing.T) {
 					functionConditionReady.Unknown(),
 				).
 				StatusKpackImageRef("%s-function-001", testName).
-				StatusTargetImage("%s/%s", testImagePrefix, testName).
-				Get(),
+				StatusTargetImage("%s/%s", testImagePrefix, testName),
 		},
 	}, {
 		Name: "create kpack image, function properties",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
+		GivenObjects: []rtesting.Factory{
 			funcValid.
 				Artifact(testArtifact).
 				Handler(testHandler).
-				Invoker(testInvoker).
-				Get(),
+				Invoker(testInvoker),
 		},
-		ExpectCreates: []runtime.Object{
+		ExpectCreates: []rtesting.Factory{
 			kpackImageCreate.
-				FunctionBuilder(testArtifact, testHandler, testInvoker).
-				Get(),
+				FunctionBuilder(testArtifact, testHandler, testInvoker),
 		},
-		ExpectStatusUpdates: []runtime.Object{
+		ExpectStatusUpdates: []rtesting.Factory{
 			funcMinimal.
 				StatusConditions(
 					functionConditionImageResolved.True(),
@@ -152,23 +148,20 @@ func TestFunctionReconciler(t *testing.T) {
 					functionConditionReady.Unknown(),
 				).
 				StatusKpackImageRef("%s-function-001", testName).
-				StatusTargetImage("%s/%s", testImagePrefix, testName).
-				Get(),
+				StatusTargetImage("%s/%s", testImagePrefix, testName),
 		},
 	}, {
 		Name: "create kpack image, build cache",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
+		GivenObjects: []rtesting.Factory{
 			funcValid.
-				BuildCache("1Gi").
-				Get(),
+				BuildCache("1Gi"),
 		},
-		ExpectCreates: []runtime.Object{
+		ExpectCreates: []rtesting.Factory{
 			kpackImageCreate.
-				BuildCache("1Gi").
-				Get(),
+				BuildCache("1Gi"),
 		},
-		ExpectStatusUpdates: []runtime.Object{
+		ExpectStatusUpdates: []rtesting.Factory{
 			funcMinimal.
 				StatusConditions(
 					functionConditionImageResolved.True(),
@@ -176,27 +169,24 @@ func TestFunctionReconciler(t *testing.T) {
 					functionConditionReady.Unknown(),
 				).
 				StatusKpackImageRef("%s-function-001", testName).
-				StatusTargetImage("%s/%s", testImagePrefix, testName).
-				Get(),
+				StatusTargetImage("%s/%s", testImagePrefix, testName),
 		},
 	}, {
 		Name: "create kpack image, propagating labels",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
+		GivenObjects: []rtesting.Factory{
 			funcValid.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.AddLabel(testLabelKey, testLabelValue)
-				}).
-				Get(),
+				}),
 		},
-		ExpectCreates: []runtime.Object{
+		ExpectCreates: []rtesting.Factory{
 			kpackImageCreate.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.AddLabel(testLabelKey, testLabelValue)
-				}).
-				Get(),
+				}),
 		},
-		ExpectStatusUpdates: []runtime.Object{
+		ExpectStatusUpdates: []rtesting.Factory{
 			funcMinimal.
 				StatusConditions(
 					functionConditionImageResolved.True(),
@@ -204,24 +194,21 @@ func TestFunctionReconciler(t *testing.T) {
 					functionConditionReady.Unknown(),
 				).
 				StatusKpackImageRef("%s-function-001", testName).
-				StatusTargetImage("%s/%s", testImagePrefix, testName).
-				Get(),
+				StatusTargetImage("%s/%s", testImagePrefix, testName),
 		},
 	}, {
 		Name: "default image",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
+		GivenObjects: []rtesting.Factory{
 			cmImagePrefix.
-				AddData("default-image-prefix", testImagePrefix).
-				Get(),
+				AddData("default-image-prefix", testImagePrefix),
 			funcMinimal.
-				SourceGit(testGitUrl, testGitRevision).
-				Get(),
+				SourceGit(testGitUrl, testGitRevision),
 		},
-		ExpectCreates: []runtime.Object{
-			kpackImageCreate.Get(),
+		ExpectCreates: []rtesting.Factory{
+			kpackImageCreate,
 		},
-		ExpectStatusUpdates: []runtime.Object{
+		ExpectStatusUpdates: []rtesting.Factory{
 			funcMinimal.
 				StatusConditions(
 					functionConditionImageResolved.True(),
@@ -229,44 +216,39 @@ func TestFunctionReconciler(t *testing.T) {
 					functionConditionReady.Unknown(),
 				).
 				StatusKpackImageRef("%s-function-001", testName).
-				StatusTargetImage("%s/%s", testImagePrefix, testName).
-				Get(),
+				StatusTargetImage("%s/%s", testImagePrefix, testName),
 		},
 	}, {
 		Name: "default image, missing",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
+		GivenObjects: []rtesting.Factory{
 			funcMinimal.
-				SourceGit(testGitUrl, testGitRevision).
-				Get(),
+				SourceGit(testGitUrl, testGitRevision),
 		},
-		ExpectStatusUpdates: []runtime.Object{
+		ExpectStatusUpdates: []rtesting.Factory{
 			funcMinimal.
 				StatusConditions(
 					functionConditionImageResolved.False().Reason("DefaultImagePrefixMissing", "missing default image prefix"),
 					functionConditionKpackImageReady.Unknown(),
 					functionConditionReady.False().Reason("DefaultImagePrefixMissing", "missing default image prefix"),
-				).
-				Get(),
+				),
 		},
 		ShouldErr: true,
 	}, {
 		Name: "default image, undefined",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
-			cmImagePrefix.Get(),
+		GivenObjects: []rtesting.Factory{
+			cmImagePrefix,
 			funcMinimal.
-				SourceGit(testGitUrl, testGitRevision).
-				Get(),
+				SourceGit(testGitUrl, testGitRevision),
 		},
-		ExpectStatusUpdates: []runtime.Object{
+		ExpectStatusUpdates: []rtesting.Factory{
 			funcMinimal.
 				StatusConditions(
 					functionConditionImageResolved.False().Reason("DefaultImagePrefixMissing", "missing default image prefix"),
 					functionConditionKpackImageReady.Unknown(),
 					functionConditionReady.False().Reason("DefaultImagePrefixMissing", "missing default image prefix"),
-				).
-				Get(),
+				),
 		},
 		ShouldErr: true,
 	}, {
@@ -275,91 +257,83 @@ func TestFunctionReconciler(t *testing.T) {
 		WithReactors: []rtesting.ReactionFunc{
 			rtesting.InduceFailure("get", "ConfigMap"),
 		},
-		GivenObjects: []runtime.Object{
-			cmImagePrefix.Get(),
+		GivenObjects: []rtesting.Factory{
+			cmImagePrefix,
 			funcMinimal.
-				SourceGit(testGitUrl, testGitRevision).
-				Get(),
+				SourceGit(testGitUrl, testGitRevision),
 		},
-		ExpectStatusUpdates: []runtime.Object{
+		ExpectStatusUpdates: []rtesting.Factory{
 			funcMinimal.
 				StatusConditions(
 					functionConditionImageResolved.False().Reason("ImageInvalid", "inducing failure for get ConfigMap"),
 					functionConditionKpackImageReady.Unknown(),
 					functionConditionReady.False().Reason("ImageInvalid", "inducing failure for get ConfigMap"),
-				).
-				Get(),
+				),
 		},
 		ShouldErr: true,
 	}, {
 		Name: "kpack image ready",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
-			funcValid.Get(),
+		GivenObjects: []rtesting.Factory{
+			funcValid,
 			kpackImageGiven.
 				StatusReady().
-				StatusLatestImage("%s/%s@sha256:%s", testImagePrefix, testName, testSha256).
-				Get(),
+				StatusLatestImage("%s/%s@sha256:%s", testImagePrefix, testName, testSha256),
 		},
-		ExpectStatusUpdates: []runtime.Object{
+		ExpectStatusUpdates: []rtesting.Factory{
 			funcMinimal.
 				StatusConditions(
 					functionConditionImageResolved.True(),
 					functionConditionKpackImageReady.True(),
 					functionConditionReady.True(),
 				).
-				StatusKpackImageRef(kpackImageGiven.Get().Name).
+				StatusKpackImageRef(kpackImageGiven.Get().GetName()).
 				StatusTargetImage("%s/%s", testImagePrefix, testName).
-				StatusLatestImage("%s/%s@sha256:%s", testImagePrefix, testName, testSha256).
-				Get(),
+				StatusLatestImage("%s/%s@sha256:%s", testImagePrefix, testName, testSha256),
 		},
 	}, {
 		Name: "kpack image ready, build cache",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
-			funcValid.Get(),
+		GivenObjects: []rtesting.Factory{
+			funcValid,
 			kpackImageGiven.
 				StatusReady().
 				StatusBuildCacheName(testBuildCacheName).
-				StatusLatestImage("%s/%s@sha256:%s", testImagePrefix, testName, testSha256).
-				Get(),
+				StatusLatestImage("%s/%s@sha256:%s", testImagePrefix, testName, testSha256),
 		},
-		ExpectStatusUpdates: []runtime.Object{
+		ExpectStatusUpdates: []rtesting.Factory{
 			funcMinimal.
 				StatusConditions(
 					functionConditionImageResolved.True(),
 					functionConditionKpackImageReady.True(),
 					functionConditionReady.True(),
 				).
-				StatusKpackImageRef(kpackImageGiven.Get().Name).
+				StatusKpackImageRef(kpackImageGiven.Get().GetName()).
 				StatusBuildCacheRef(testBuildCacheName).
 				StatusTargetImage("%s/%s", testImagePrefix, testName).
-				StatusLatestImage("%s/%s@sha256:%s", testImagePrefix, testName, testSha256).
-				Get(),
+				StatusLatestImage("%s/%s@sha256:%s", testImagePrefix, testName, testSha256),
 		},
 	}, {
 		Name: "kpack image not-ready",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
-			funcValid.Get(),
+		GivenObjects: []rtesting.Factory{
+			funcValid,
 			kpackImageGiven.
 				StatusConditions(
 					factories.Condition().Type(apis.ConditionReady).False().Reason(testConditionReason, testConditionMessage),
 				).
-				StatusLatestImage("%s/%s@sha256:%s", testImagePrefix, testName, testSha256).
-				Get(),
+				StatusLatestImage("%s/%s@sha256:%s", testImagePrefix, testName, testSha256),
 		},
-		ExpectStatusUpdates: []runtime.Object{
+		ExpectStatusUpdates: []rtesting.Factory{
 			funcMinimal.
 				StatusConditions(
 					functionConditionImageResolved.True(),
 					functionConditionKpackImageReady.False().Reason(testConditionReason, testConditionMessage),
 					functionConditionReady.False().Reason(testConditionReason, testConditionMessage),
 				).
-				StatusKpackImageRef(kpackImageGiven.Get().Name).
+				StatusKpackImageRef(kpackImageGiven.Get().GetName()).
 				StatusTargetImage("%s/%s", testImagePrefix, testName).
-				StatusLatestImage("%s/%s@sha256:%s", testImagePrefix, testName, testSha256).
-				Get(),
+				StatusLatestImage("%s/%s@sha256:%s", testImagePrefix, testName, testSha256),
 		},
 	}, {
 		Name: "kpack image create error",
@@ -367,74 +341,68 @@ func TestFunctionReconciler(t *testing.T) {
 		WithReactors: []rtesting.ReactionFunc{
 			rtesting.InduceFailure("create", "Image"),
 		},
-		GivenObjects: []runtime.Object{
-			funcValid.Get(),
+		GivenObjects: []rtesting.Factory{
+			funcValid,
 		},
 		ShouldErr: true,
-		ExpectCreates: []runtime.Object{
-			kpackImageCreate.Get(),
+		ExpectCreates: []rtesting.Factory{
+			kpackImageCreate,
 		},
-		ExpectStatusUpdates: []runtime.Object{
+		ExpectStatusUpdates: []rtesting.Factory{
 			funcValid.
 				StatusConditions(
 					functionConditionImageResolved.True(),
 					functionConditionKpackImageReady.Unknown(),
 					functionConditionReady.Unknown(),
 				).
-				StatusTargetImage("%s/%s", testImagePrefix, testName).
-				Get(),
+				StatusTargetImage("%s/%s", testImagePrefix, testName),
 		},
 	}, {
 		Name: "kpack image update, spec",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
-			funcValid.Get(),
+		GivenObjects: []rtesting.Factory{
+			funcValid,
 			kpackImageGiven.
-				SourceGit(testGitUrl, "bogus").
-				Get(),
+				SourceGit(testGitUrl, "bogus"),
 		},
-		ExpectUpdates: []runtime.Object{
-			kpackImageGiven.Get(),
+		ExpectUpdates: []rtesting.Factory{
+			kpackImageGiven,
 		},
-		ExpectStatusUpdates: []runtime.Object{
+		ExpectStatusUpdates: []rtesting.Factory{
 			funcValid.
 				StatusConditions(
 					functionConditionImageResolved.True(),
 					functionConditionKpackImageReady.Unknown(),
 					functionConditionReady.Unknown(),
 				).
-				StatusKpackImageRef(kpackImageGiven.Get().Name).
-				StatusTargetImage("%s/%s", testImagePrefix, testName).
-				Get(),
+				StatusKpackImageRef(kpackImageGiven.Get().GetName()).
+				StatusTargetImage("%s/%s", testImagePrefix, testName),
 		},
 	}, {
 		Name: "kpack image update, labels",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
+		GivenObjects: []rtesting.Factory{
 			funcValid.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.AddLabel(testLabelKey, testLabelValue)
-				}).
-				Get(),
-			kpackImageGiven.Get(),
+				}),
+			kpackImageGiven,
 		},
-		ExpectUpdates: []runtime.Object{
+		ExpectUpdates: []rtesting.Factory{
 			kpackImageGiven.
 				ObjectMeta(func(om factories.ObjectMeta) {
 					om.AddLabel(testLabelKey, testLabelValue)
-				}).
-				Get(),
+				}),
 		},
-		ExpectStatusUpdates: []runtime.Object{
+		ExpectStatusUpdates: []rtesting.Factory{
 			funcValid.
 				StatusConditions(
 					functionConditionImageResolved.True(),
 					functionConditionKpackImageReady.Unknown(),
 					functionConditionReady.Unknown(),
 				).
-				StatusKpackImageRef(kpackImageGiven.Get().Name).
-				StatusTargetImage("%s/%s", testImagePrefix, testName).
-				Get(),
+				StatusKpackImageRef(kpackImageGiven.Get().GetName()).
+				StatusTargetImage("%s/%s", testImagePrefix, testName),
 		},
 	}, {
 		Name: "kpack image update, fails",
@@ -442,25 +410,23 @@ func TestFunctionReconciler(t *testing.T) {
 		WithReactors: []rtesting.ReactionFunc{
 			rtesting.InduceFailure("update", "Image"),
 		},
-		GivenObjects: []runtime.Object{
-			funcValid.Get(),
+		GivenObjects: []rtesting.Factory{
+			funcValid,
 			kpackImageGiven.
-				SourceGit(testGitUrl, "bogus").
-				Get(),
+				SourceGit(testGitUrl, "bogus"),
 		},
 		ShouldErr: true,
-		ExpectUpdates: []runtime.Object{
-			kpackImageGiven.Get(),
+		ExpectUpdates: []rtesting.Factory{
+			kpackImageGiven,
 		},
-		ExpectStatusUpdates: []runtime.Object{
+		ExpectStatusUpdates: []rtesting.Factory{
 			funcValid.
 				StatusConditions(
 					functionConditionImageResolved.True(),
 					functionConditionKpackImageReady.Unknown(),
 					functionConditionReady.Unknown(),
 				).
-				StatusTargetImage("%s/%s", testImagePrefix, testName).
-				Get(),
+				StatusTargetImage("%s/%s", testImagePrefix, testName),
 		},
 	}, {
 		Name: "kpack image list error",
@@ -468,19 +434,18 @@ func TestFunctionReconciler(t *testing.T) {
 		WithReactors: []rtesting.ReactionFunc{
 			rtesting.InduceFailure("list", "ImageList"),
 		},
-		GivenObjects: []runtime.Object{
-			funcValid.Get(),
+		GivenObjects: []rtesting.Factory{
+			funcValid,
 		},
 		ShouldErr: true,
-		ExpectStatusUpdates: []runtime.Object{
+		ExpectStatusUpdates: []rtesting.Factory{
 			funcValid.
 				StatusConditions(
 					functionConditionImageResolved.True(),
 					functionConditionKpackImageReady.Unknown(),
 					functionConditionReady.Unknown(),
 				).
-				StatusTargetImage("%s/%s", testImagePrefix, testName).
-				Get(),
+				StatusTargetImage("%s/%s", testImagePrefix, testName),
 		},
 	}, {
 		Name: "function status update error",
@@ -488,13 +453,13 @@ func TestFunctionReconciler(t *testing.T) {
 		WithReactors: []rtesting.ReactionFunc{
 			rtesting.InduceFailure("update", "Function"),
 		},
-		GivenObjects: []runtime.Object{
-			funcValid.Get(),
+		GivenObjects: []rtesting.Factory{
+			funcValid,
 		},
-		ExpectCreates: []runtime.Object{
-			kpackImageCreate.Get(),
+		ExpectCreates: []rtesting.Factory{
+			kpackImageCreate,
 		},
-		ExpectStatusUpdates: []runtime.Object{
+		ExpectStatusUpdates: []rtesting.Factory{
 			funcMinimal.
 				StatusConditions(
 					functionConditionImageResolved.True(),
@@ -502,30 +467,27 @@ func TestFunctionReconciler(t *testing.T) {
 					functionConditionReady.Unknown(),
 				).
 				StatusKpackImageRef("%s-function-001", testName).
-				StatusTargetImage("%s/%s", testImagePrefix, testName).
-				Get(),
+				StatusTargetImage("%s/%s", testImagePrefix, testName),
 		},
 		ShouldErr: true,
 	}, {
 		Name: "delete extra kpack image",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
-			funcValid.Get(),
+		GivenObjects: []rtesting.Factory{
+			funcValid,
 			kpackImageGiven.
-				NamespaceName(testNamespace, "extra1").
-				Get(),
+				NamespaceName(testNamespace, "extra1"),
 			kpackImageGiven.
-				NamespaceName(testNamespace, "extra2").
-				Get(),
+				NamespaceName(testNamespace, "extra2"),
 		},
 		ExpectDeletes: []rtesting.DeleteRef{
 			{Group: "build.pivotal.io", Kind: "Image", Namespace: testNamespace, Name: "extra1"},
 			{Group: "build.pivotal.io", Kind: "Image", Namespace: testNamespace, Name: "extra2"},
 		},
-		ExpectCreates: []runtime.Object{
-			kpackImageCreate.Get(),
+		ExpectCreates: []rtesting.Factory{
+			kpackImageCreate,
 		},
-		ExpectStatusUpdates: []runtime.Object{
+		ExpectStatusUpdates: []rtesting.Factory{
 			funcMinimal.
 				StatusConditions(
 					functionConditionImageResolved.True(),
@@ -533,8 +495,7 @@ func TestFunctionReconciler(t *testing.T) {
 					functionConditionReady.Unknown(),
 				).
 				StatusKpackImageRef("%s-function-001", testName).
-				StatusTargetImage("%s/%s", testImagePrefix, testName).
-				Get(),
+				StatusTargetImage("%s/%s", testImagePrefix, testName),
 		},
 	}, {
 		Name: "delete extra kpack image, fails",
@@ -542,38 +503,34 @@ func TestFunctionReconciler(t *testing.T) {
 		WithReactors: []rtesting.ReactionFunc{
 			rtesting.InduceFailure("delete", "Image"),
 		},
-		GivenObjects: []runtime.Object{
-			funcValid.Get(),
+		GivenObjects: []rtesting.Factory{
+			funcValid,
 			kpackImageGiven.
-				NamespaceName(testNamespace, "extra1").
-				Get(),
+				NamespaceName(testNamespace, "extra1"),
 			kpackImageGiven.
-				NamespaceName(testNamespace, "extra2").
-				Get(),
+				NamespaceName(testNamespace, "extra2"),
 		},
 		ShouldErr: true,
 		ExpectDeletes: []rtesting.DeleteRef{
 			{Group: "build.pivotal.io", Kind: "Image", Namespace: testNamespace, Name: "extra1"},
 		},
-		ExpectStatusUpdates: []runtime.Object{
+		ExpectStatusUpdates: []rtesting.Factory{
 			funcMinimal.
 				StatusConditions(
 					functionConditionImageResolved.True(),
 					functionConditionKpackImageReady.Unknown(),
 					functionConditionReady.Unknown(),
 				).
-				StatusTargetImage("%s/%s", testImagePrefix, testName).
-				Get(),
+				StatusTargetImage("%s/%s", testImagePrefix, testName),
 		},
 	}, {
 		Name: "local build",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
+		GivenObjects: []rtesting.Factory{
 			funcMinimal.
-				Image("%s/%s", testImagePrefix, testName).
-				Get(),
+				Image("%s/%s", testImagePrefix, testName),
 		},
-		ExpectStatusUpdates: []runtime.Object{
+		ExpectStatusUpdates: []rtesting.Factory{
 			funcMinimal.
 				StatusConditions(
 					functionConditionImageResolved.True(),
@@ -582,22 +539,20 @@ func TestFunctionReconciler(t *testing.T) {
 				).
 				StatusTargetImage("%s/%s", testImagePrefix, testName).
 				// TODO resolve to a digest
-				StatusLatestImage("%s/%s", testImagePrefix, testName).
-				Get(),
+				StatusLatestImage("%s/%s", testImagePrefix, testName),
 		},
 	}, {
 		Name: "local build, removes existing build",
 		Key:  testKey,
-		GivenObjects: []runtime.Object{
+		GivenObjects: []rtesting.Factory{
 			funcMinimal.
-				Image("%s/%s", testImagePrefix, testName).
-				Get(),
-			kpackImageGiven.Get(),
+				Image("%s/%s", testImagePrefix, testName),
+			kpackImageGiven,
 		},
 		ExpectDeletes: []rtesting.DeleteRef{
-			{Group: "build.pivotal.io", Kind: "Image", Namespace: kpackImageGiven.Get().Namespace, Name: kpackImageGiven.Get().Name},
+			{Group: "build.pivotal.io", Kind: "Image", Namespace: kpackImageGiven.Get().GetNamespace(), Name: kpackImageGiven.Get().GetName()},
 		},
-		ExpectStatusUpdates: []runtime.Object{
+		ExpectStatusUpdates: []rtesting.Factory{
 			funcMinimal.
 				StatusConditions(
 					functionConditionImageResolved.True(),
@@ -606,8 +561,7 @@ func TestFunctionReconciler(t *testing.T) {
 				).
 				StatusTargetImage("%s/%s", testImagePrefix, testName).
 				// TODO resolve to a digest
-				StatusLatestImage("%s/%s", testImagePrefix, testName).
-				Get(),
+				StatusLatestImage("%s/%s", testImagePrefix, testName),
 		},
 	}, {
 		Name: "local build, removes existing build, error",
@@ -615,25 +569,23 @@ func TestFunctionReconciler(t *testing.T) {
 		WithReactors: []rtesting.ReactionFunc{
 			rtesting.InduceFailure("delete", "Image"),
 		},
-		GivenObjects: []runtime.Object{
+		GivenObjects: []rtesting.Factory{
 			funcMinimal.
-				Image("%s/%s", testImagePrefix, testName).
-				Get(),
-			kpackImageGiven.Get(),
+				Image("%s/%s", testImagePrefix, testName),
+			kpackImageGiven,
 		},
 		ShouldErr: true,
 		ExpectDeletes: []rtesting.DeleteRef{
-			{Group: "build.pivotal.io", Kind: "Image", Namespace: kpackImageGiven.Get().Namespace, Name: kpackImageGiven.Get().Name},
+			{Group: "build.pivotal.io", Kind: "Image", Namespace: kpackImageGiven.Get().GetNamespace(), Name: kpackImageGiven.Get().GetName()},
 		},
-		ExpectStatusUpdates: []runtime.Object{
+		ExpectStatusUpdates: []rtesting.Factory{
 			funcMinimal.
 				StatusConditions(
 					functionConditionImageResolved.True(),
 					functionConditionKpackImageReady.Unknown(),
 					functionConditionReady.Unknown(),
 				).
-				StatusTargetImage("%s/%s", testImagePrefix, testName).
-				Get(),
+				StatusTargetImage("%s/%s", testImagePrefix, testName),
 		},
 	}}
 

--- a/pkg/controllers/testing/factories/adapter_knative.go
+++ b/pkg/controllers/testing/factories/adapter_knative.go
@@ -21,11 +21,16 @@ import (
 
 	"github.com/projectriff/system/pkg/apis"
 	knativev1alpha1 "github.com/projectriff/system/pkg/apis/knative/v1alpha1"
+	rtesting "github.com/projectriff/system/pkg/controllers/testing"
 )
 
 type adapterKnative struct {
 	target *knativev1alpha1.Adapter
 }
+
+var (
+	_ rtesting.Factory = (*adapterKnative)(nil)
+)
 
 func AdapterKnative(seed ...*knativev1alpha1.Adapter) *adapterKnative {
 	var target *knativev1alpha1.Adapter
@@ -46,7 +51,7 @@ func (f *adapterKnative) deepCopy() *adapterKnative {
 	return AdapterKnative(f.target.DeepCopy())
 }
 
-func (f *adapterKnative) Get() *knativev1alpha1.Adapter {
+func (f *adapterKnative) Get() apis.Object {
 	return f.deepCopy().target
 }
 

--- a/pkg/controllers/testing/factories/application.go
+++ b/pkg/controllers/testing/factories/application.go
@@ -31,6 +31,10 @@ type application struct {
 	target *buildv1alpha1.Application
 }
 
+var (
+	_ rtesting.Factory = (*application)(nil)
+)
+
 func Application(seed ...*buildv1alpha1.Application) *application {
 	var target *buildv1alpha1.Application
 	switch len(seed) {
@@ -50,7 +54,7 @@ func (f *application) deepCopy() *application {
 	return Application(f.target.DeepCopy())
 }
 
-func (f *application) Get() *buildv1alpha1.Application {
+func (f *application) Get() apis.Object {
 	return f.deepCopy().target
 }
 

--- a/pkg/controllers/testing/factories/configmap.go
+++ b/pkg/controllers/testing/factories/configmap.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/projectriff/system/pkg/apis"
 )
 
 type configMap struct {
@@ -45,7 +47,7 @@ func (f *configMap) deepCopy() *configMap {
 	return ConfigMap(f.target.DeepCopy())
 }
 
-func (f *configMap) Get() *corev1.ConfigMap {
+func (f *configMap) Get() apis.Object {
 	return f.deepCopy().target
 }
 

--- a/pkg/controllers/testing/factories/configmap.go
+++ b/pkg/controllers/testing/factories/configmap.go
@@ -22,11 +22,16 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/projectriff/system/pkg/apis"
+	rtesting "github.com/projectriff/system/pkg/controllers/testing"
 )
 
 type configMap struct {
 	target *corev1.ConfigMap
 }
+
+var (
+	_ rtesting.Factory = (*configMap)(nil)
+)
 
 func ConfigMap(seed ...*corev1.ConfigMap) *configMap {
 	var target *corev1.ConfigMap

--- a/pkg/controllers/testing/factories/container.go
+++ b/pkg/controllers/testing/factories/container.go
@@ -21,11 +21,16 @@ import (
 
 	"github.com/projectriff/system/pkg/apis"
 	buildv1alpha1 "github.com/projectriff/system/pkg/apis/build/v1alpha1"
+	rtesting "github.com/projectriff/system/pkg/controllers/testing"
 )
 
 type container struct {
 	target *buildv1alpha1.Container
 }
+
+var (
+	_ rtesting.Factory = (*container)(nil)
+)
 
 func Container(seed ...*buildv1alpha1.Container) *container {
 	var target *buildv1alpha1.Container

--- a/pkg/controllers/testing/factories/container.go
+++ b/pkg/controllers/testing/factories/container.go
@@ -46,7 +46,7 @@ func (f *container) deepCopy() *container {
 	return Container(f.target.DeepCopy())
 }
 
-func (f *container) Get() *buildv1alpha1.Container {
+func (f *container) Get() apis.Object {
 	return f.deepCopy().target
 }
 

--- a/pkg/controllers/testing/factories/deployer_core.go
+++ b/pkg/controllers/testing/factories/deployer_core.go
@@ -31,6 +31,10 @@ type deployerCore struct {
 	target *corev1alpha1.Deployer
 }
 
+var (
+	_ rtesting.Factory = (*deployerCore)(nil)
+)
+
 func DeployerCore(seed ...*corev1alpha1.Deployer) *deployerCore {
 	var target *corev1alpha1.Deployer
 	switch len(seed) {
@@ -50,7 +54,7 @@ func (f *deployerCore) deepCopy() *deployerCore {
 	return DeployerCore(f.target.DeepCopy())
 }
 
-func (f *deployerCore) Get() *corev1alpha1.Deployer {
+func (f *deployerCore) Get() apis.Object {
 	return f.deepCopy().target
 }
 

--- a/pkg/controllers/testing/factories/deployer_knative.go
+++ b/pkg/controllers/testing/factories/deployer_knative.go
@@ -31,6 +31,10 @@ type deployerKnative struct {
 	target *knativev1alpha1.Deployer
 }
 
+var (
+	_ rtesting.Factory = (*deployerKnative)(nil)
+)
+
 func DeployerKnative(seed ...*knativev1alpha1.Deployer) *deployerKnative {
 	var target *knativev1alpha1.Deployer
 	switch len(seed) {
@@ -50,7 +54,7 @@ func (f *deployerKnative) deepCopy() *deployerKnative {
 	return DeployerKnative(f.target.DeepCopy())
 }
 
-func (f *deployerKnative) Get() *knativev1alpha1.Deployer {
+func (f *deployerKnative) Get() apis.Object {
 	return f.deepCopy().target
 }
 

--- a/pkg/controllers/testing/factories/deployment.go
+++ b/pkg/controllers/testing/factories/deployment.go
@@ -31,6 +31,10 @@ type deployment struct {
 	target *appsv1.Deployment
 }
 
+var (
+	_ rtesting.Factory = (*deployment)(nil)
+)
+
 func Deployment(seed ...*appsv1.Deployment) *deployment {
 	var target *appsv1.Deployment
 	switch len(seed) {

--- a/pkg/controllers/testing/factories/deployment.go
+++ b/pkg/controllers/testing/factories/deployment.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/projectriff/system/pkg/apis"
 	rtesting "github.com/projectriff/system/pkg/controllers/testing"
 )
 
@@ -49,7 +50,7 @@ func (f *deployment) deepCopy() *deployment {
 	return Deployment(f.target.DeepCopy())
 }
 
-func (f *deployment) Get() *appsv1.Deployment {
+func (f *deployment) Get() apis.Object {
 	return f.deepCopy().target
 }
 

--- a/pkg/controllers/testing/factories/function.go
+++ b/pkg/controllers/testing/factories/function.go
@@ -50,7 +50,7 @@ func (f *function) deepCopy() *function {
 	return Function(f.target.DeepCopy())
 }
 
-func (f *function) Get() *buildv1alpha1.Function {
+func (f *function) Get() apis.Object {
 	return f.deepCopy().target
 }
 

--- a/pkg/controllers/testing/factories/function.go
+++ b/pkg/controllers/testing/factories/function.go
@@ -31,6 +31,10 @@ type function struct {
 	target *buildv1alpha1.Function
 }
 
+var (
+	_ rtesting.Factory = (*function)(nil)
+)
+
 func Function(seed ...*buildv1alpha1.Function) *function {
 	var target *buildv1alpha1.Function
 	switch len(seed) {

--- a/pkg/controllers/testing/factories/ingress.go
+++ b/pkg/controllers/testing/factories/ingress.go
@@ -22,11 +22,18 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/projectriff/system/pkg/apis"
+	rtesting "github.com/projectriff/system/pkg/controllers/testing"
 )
 
 type ingress struct {
 	target *networkingv1beta1.Ingress
 }
+
+var (
+	_ rtesting.Factory = (*ingress)(nil)
+)
 
 func Ingress(seed ...*networkingv1beta1.Ingress) *ingress {
 	var target *networkingv1beta1.Ingress
@@ -47,7 +54,7 @@ func (f *ingress) deepCopy() *ingress {
 	return Ingress(f.target.DeepCopy())
 }
 
-func (f *ingress) Get() *networkingv1beta1.Ingress {
+func (f *ingress) Get() apis.Object {
 	return f.deepCopy().target
 }
 

--- a/pkg/controllers/testing/factories/keda_scaledobject.go
+++ b/pkg/controllers/testing/factories/keda_scaledobject.go
@@ -21,11 +21,16 @@ import (
 
 	"github.com/projectriff/system/pkg/apis"
 	kedav1alpha1 "github.com/projectriff/system/pkg/apis/thirdparty/keda/v1alpha1"
+	rtesting "github.com/projectriff/system/pkg/controllers/testing"
 )
 
 type kedaScaledObject struct {
 	target *kedav1alpha1.ScaledObject
 }
+
+var (
+	_ rtesting.Factory = (*kedaScaledObject)(nil)
+)
 
 func KedaScaledObject(seed ...*kedav1alpha1.ScaledObject) *kedaScaledObject {
 	var target *kedav1alpha1.ScaledObject

--- a/pkg/controllers/testing/factories/keda_scaledobject.go
+++ b/pkg/controllers/testing/factories/keda_scaledobject.go
@@ -19,6 +19,7 @@ package factories
 import (
 	"fmt"
 
+	"github.com/projectriff/system/pkg/apis"
 	kedav1alpha1 "github.com/projectriff/system/pkg/apis/thirdparty/keda/v1alpha1"
 )
 
@@ -45,7 +46,7 @@ func (f *kedaScaledObject) deepCopy() *kedaScaledObject {
 	return KedaScaledObject(f.target.DeepCopy())
 }
 
-func (f *kedaScaledObject) Get() *kedav1alpha1.ScaledObject {
+func (f *kedaScaledObject) Get() apis.Object {
 	return f.deepCopy().target
 }
 

--- a/pkg/controllers/testing/factories/knative_configuration.go
+++ b/pkg/controllers/testing/factories/knative_configuration.go
@@ -23,11 +23,16 @@ import (
 
 	"github.com/projectriff/system/pkg/apis"
 	knativeservingv1 "github.com/projectriff/system/pkg/apis/thirdparty/knative/serving/v1"
+	rtesting "github.com/projectriff/system/pkg/controllers/testing"
 )
 
 type knativeConfiguration struct {
 	target *knativeservingv1.Configuration
 }
+
+var (
+	_ rtesting.Factory = (*knativeConfiguration)(nil)
+)
 
 func KnativeConfiguration(seed ...*knativeservingv1.Configuration) *knativeConfiguration {
 	var target *knativeservingv1.Configuration
@@ -48,7 +53,7 @@ func (f *knativeConfiguration) deepCopy() *knativeConfiguration {
 	return KnativeConfiguration(f.target.DeepCopy())
 }
 
-func (f *knativeConfiguration) Get() *knativeservingv1.Configuration {
+func (f *knativeConfiguration) Get() apis.Object {
 	return f.deepCopy().target
 }
 

--- a/pkg/controllers/testing/factories/knative_route.go
+++ b/pkg/controllers/testing/factories/knative_route.go
@@ -21,11 +21,16 @@ import (
 
 	"github.com/projectriff/system/pkg/apis"
 	knativeservingv1 "github.com/projectriff/system/pkg/apis/thirdparty/knative/serving/v1"
+	rtesting "github.com/projectriff/system/pkg/controllers/testing"
 )
 
 type knativeRoute struct {
 	target *knativeservingv1.Route
 }
+
+var (
+	_ rtesting.Factory = (*knativeRoute)(nil)
+)
 
 func KnativeRoute(seed ...*knativeservingv1.Route) *knativeRoute {
 	var target *knativeservingv1.Route
@@ -46,7 +51,7 @@ func (f *knativeRoute) deepCopy() *knativeRoute {
 	return KnativeRoute(f.target.DeepCopy())
 }
 
-func (f *knativeRoute) Get() *knativeservingv1.Route {
+func (f *knativeRoute) Get() apis.Object {
 	return f.deepCopy().target
 }
 

--- a/pkg/controllers/testing/factories/knative_service.go
+++ b/pkg/controllers/testing/factories/knative_service.go
@@ -23,11 +23,16 @@ import (
 
 	"github.com/projectriff/system/pkg/apis"
 	knativeservingv1 "github.com/projectriff/system/pkg/apis/thirdparty/knative/serving/v1"
+	rtesting "github.com/projectriff/system/pkg/controllers/testing"
 )
 
 type knativeService struct {
 	target *knativeservingv1.Service
 }
+
+var (
+	_ rtesting.Factory = (*knativeService)(nil)
+)
 
 func KnativeService(seed ...*knativeservingv1.Service) *knativeService {
 	var target *knativeservingv1.Service
@@ -48,7 +53,7 @@ func (f *knativeService) deepCopy() *knativeService {
 	return KnativeService(f.target.DeepCopy())
 }
 
-func (f *knativeService) Get() *knativeservingv1.Service {
+func (f *knativeService) Get() apis.Object {
 	return f.deepCopy().target
 }
 

--- a/pkg/controllers/testing/factories/kpack_clusterbuilder.go
+++ b/pkg/controllers/testing/factories/kpack_clusterbuilder.go
@@ -21,11 +21,16 @@ import (
 
 	"github.com/projectriff/system/pkg/apis"
 	kpackbuildv1alpha1 "github.com/projectriff/system/pkg/apis/thirdparty/kpack/build/v1alpha1"
+	rtesting "github.com/projectriff/system/pkg/controllers/testing"
 )
 
 type kpackClusterBuilder struct {
 	target *kpackbuildv1alpha1.ClusterBuilder
 }
+
+var (
+	_ rtesting.Factory = (*kpackClusterBuilder)(nil)
+)
 
 func KpackClusterBuilder(seed ...*kpackbuildv1alpha1.ClusterBuilder) *kpackClusterBuilder {
 	var target *kpackbuildv1alpha1.ClusterBuilder
@@ -46,7 +51,7 @@ func (f *kpackClusterBuilder) deepCopy() *kpackClusterBuilder {
 	return KpackClusterBuilder(f.target.DeepCopy())
 }
 
-func (f *kpackClusterBuilder) Get() *kpackbuildv1alpha1.ClusterBuilder {
+func (f *kpackClusterBuilder) Get() apis.Object {
 	return f.deepCopy().target
 }
 

--- a/pkg/controllers/testing/factories/kpack_image.go
+++ b/pkg/controllers/testing/factories/kpack_image.go
@@ -25,11 +25,16 @@ import (
 
 	"github.com/projectriff/system/pkg/apis"
 	kpackbuildv1alpha1 "github.com/projectriff/system/pkg/apis/thirdparty/kpack/build/v1alpha1"
+	rtesting "github.com/projectriff/system/pkg/controllers/testing"
 )
 
 type kpackImage struct {
 	target *kpackbuildv1alpha1.Image
 }
+
+var (
+	_ rtesting.Factory = (*kpackImage)(nil)
+)
 
 func KpackImage(seed ...*kpackbuildv1alpha1.Image) *kpackImage {
 	var target *kpackbuildv1alpha1.Image
@@ -50,7 +55,7 @@ func (f *kpackImage) deepCopy() *kpackImage {
 	return KpackImage(f.target.DeepCopy())
 }
 
-func (f *kpackImage) Get() *kpackbuildv1alpha1.Image {
+func (f *kpackImage) Get() apis.Object {
 	return f.deepCopy().target
 }
 

--- a/pkg/controllers/testing/factories/objectmeta.go
+++ b/pkg/controllers/testing/factories/objectmeta.go
@@ -22,6 +22,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/projectriff/system/pkg/controllers/testing"
 )
 
 type ObjectMeta interface {
@@ -34,7 +36,7 @@ type ObjectMeta interface {
 	AddLabel(key, value string) ObjectMeta
 	AddAnnotation(key, value string) ObjectMeta
 	Generation(generation int64) ObjectMeta
-	ControlledBy(owner metav1.Object, scheme *runtime.Scheme) ObjectMeta
+	ControlledBy(owner testing.Factory, scheme *runtime.Scheme) ObjectMeta
 	Created(sec int64) ObjectMeta
 	Deleted(sec int64) ObjectMeta
 }
@@ -100,9 +102,9 @@ func (f *objectMetaImpl) Generation(generation int64) ObjectMeta {
 	})
 }
 
-func (f *objectMetaImpl) ControlledBy(owner metav1.Object, scheme *runtime.Scheme) ObjectMeta {
+func (f *objectMetaImpl) ControlledBy(owner testing.Factory, scheme *runtime.Scheme) ObjectMeta {
 	return f.Mutate(func(om *metav1.ObjectMeta) {
-		err := ctrl.SetControllerReference(owner, om, scheme)
+		err := ctrl.SetControllerReference(owner.Get(), om, scheme)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/controllers/testing/factories/processor.go
+++ b/pkg/controllers/testing/factories/processor.go
@@ -31,6 +31,10 @@ type processor struct {
 	target *streamingv1alpha1.Processor
 }
 
+var (
+	_ rtesting.Factory = (*processor)(nil)
+)
+
 func Processor(seed ...*streamingv1alpha1.Processor) *processor {
 	var target *streamingv1alpha1.Processor
 	switch len(seed) {

--- a/pkg/controllers/testing/factories/processor.go
+++ b/pkg/controllers/testing/factories/processor.go
@@ -50,7 +50,7 @@ func (f *processor) deepCopy() *processor {
 	return Processor(f.target.DeepCopy())
 }
 
-func (f *processor) Get() *streamingv1alpha1.Processor {
+func (f *processor) Get() apis.Object {
 	return f.deepCopy().target
 }
 

--- a/pkg/controllers/testing/factories/secret.go
+++ b/pkg/controllers/testing/factories/secret.go
@@ -21,11 +21,18 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/projectriff/system/pkg/apis"
+	rtesting "github.com/projectriff/system/pkg/controllers/testing"
 )
 
 type secret struct {
 	target *corev1.Secret
 }
+
+var (
+	_ rtesting.Factory = (*secret)(nil)
+)
 
 func Secret(seed ...*corev1.Secret) *secret {
 	var target *corev1.Secret
@@ -46,7 +53,7 @@ func (f *secret) deepCopy() *secret {
 	return Secret(f.target.DeepCopy())
 }
 
-func (f *secret) Get() *corev1.Secret {
+func (f *secret) Get() apis.Object {
 	return f.deepCopy().target
 }
 

--- a/pkg/controllers/testing/factories/service.go
+++ b/pkg/controllers/testing/factories/service.go
@@ -20,11 +20,18 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/projectriff/system/pkg/apis"
+	rtesting "github.com/projectriff/system/pkg/controllers/testing"
 )
 
 type service struct {
 	target *corev1.Service
 }
+
+var (
+	_ rtesting.Factory = (*service)(nil)
+)
 
 func Service(seed ...*corev1.Service) *service {
 	var target *corev1.Service
@@ -45,7 +52,7 @@ func (f *service) deepCopy() *service {
 	return Service(f.target.DeepCopy())
 }
 
-func (f *service) Get() *corev1.Service {
+func (f *service) Get() apis.Object {
 	return f.deepCopy().target
 }
 

--- a/pkg/controllers/testing/factories/serviceaccount.go
+++ b/pkg/controllers/testing/factories/serviceaccount.go
@@ -20,11 +20,18 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/projectriff/system/pkg/apis"
+	rtesting "github.com/projectriff/system/pkg/controllers/testing"
 )
 
 type serviceAccount struct {
 	target *corev1.ServiceAccount
 }
+
+var (
+	_ rtesting.Factory = (*serviceAccount)(nil)
+)
 
 func ServiceAccount(seed ...*corev1.ServiceAccount) *serviceAccount {
 	var target *corev1.ServiceAccount
@@ -45,7 +52,7 @@ func (f *serviceAccount) deepCopy() *serviceAccount {
 	return ServiceAccount(f.target.DeepCopy())
 }
 
-func (f *serviceAccount) Get() *corev1.ServiceAccount {
+func (f *serviceAccount) Get() apis.Object {
 	return f.deepCopy().target
 }
 

--- a/pkg/controllers/testing/factory.go
+++ b/pkg/controllers/testing/factory.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2020 the original author or authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"github.com/projectriff/system/pkg/apis"
+)
+
+// Factory creates Kubernetes objects
+type Factory interface {
+	// Get returns a Kubernetes object
+	Get() apis.Object
+}

--- a/pkg/controllers/testing/tracker.go
+++ b/pkg/controllers/testing/tracker.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/projectriff/system/pkg/apis"
 	"github.com/projectriff/system/pkg/tracker"
 )
 
@@ -51,7 +50,8 @@ func CreateTrackRequest(trackedObjGroup, trackedObjKind, trackedObjNamespace, tr
 	}
 }
 
-func NewTrackRequest(tracked, by apis.Object, scheme *runtime.Scheme) TrackRequest {
+func NewTrackRequest(t, b Factory, scheme *runtime.Scheme) TrackRequest {
+	tracked, by := t.Get(), b.Get()
 	gvks, _, err := scheme.ObjectKinds(tracked)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
The general idea is to avoid the proliferation of `Get()` calls and use factories instead of built objects in table rows.

The spike makes the necessary changes to the test framework and factories, but applies the changes to a single test.