### PR TITLE
Improve factory terminology

### DIFF
--- a/pkg/controllers/build/clusterbuilder_controller_test.go
+++ b/pkg/controllers/build/clusterbuilder_controller_test.go
@@ -29,7 +29,7 @@ import (
 	kpackbuildv1alpha1 "github.com/projectriff/system/pkg/apis/thirdparty/kpack/build/v1alpha1"
 	"github.com/projectriff/system/pkg/controllers/build"
 	rtesting "github.com/projectriff/system/pkg/controllers/testing"
-	"github.com/projectriff/system/pkg/controllers/testing/factories"
+	"github.com/projectriff/system/pkg/controllers/testing/builders"
 	"github.com/projectriff/system/pkg/tracker"
 )
 
@@ -44,45 +44,45 @@ func TestClusterBuildersReconciler(t *testing.T) {
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = kpackbuildv1alpha1.AddToScheme(scheme)
 
-	testApplicationBuilder := factories.KpackClusterBuilder().
+	testApplicationBuilder := builders.KpackClusterBuilder().
 		NamespaceName("", "riff-application").
 		Image(testApplicationImage)
 	testApplicationBuilderReady := testApplicationBuilder.
 		StatusReady().
 		StatusLatestImage(testApplicationImage)
-	testFunctionBuilder := factories.KpackClusterBuilder().
+	testFunctionBuilder := builders.KpackClusterBuilder().
 		NamespaceName("", "riff-function").
 		Image(testFunctionImage)
 	testFunctionBuilderReady := testFunctionBuilder.
 		StatusReady().
 		StatusLatestImage(testFunctionImage)
 
-	testBuilders := factories.ConfigMap().
+	testBuilders := builders.ConfigMap().
 		NamespaceName(testNamespace, testName)
 
 	table := rtesting.Table{{
 		Name: "builders configmap does not exist",
 		Key:  testKey,
 		ExpectCreates: []runtime.Object{
-			testBuilders.Get(),
+			testBuilders.Build(),
 		},
 	}, {
 		Name: "builders configmap unchanged",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			testBuilders.Get(),
+			testBuilders.Build(),
 		},
 	}, {
 		Name: "ignore deleted builders configmap",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
 			testBuilders.
-				ObjectMeta(func(om factories.ObjectMeta) {
+				ObjectMeta(func(om builders.ObjectMeta) {
 					om.Deleted(1)
 				}).
-				Get(),
-			testApplicationBuilder.Get(),
-			testFunctionBuilder.Get(),
+				Build(),
+			testApplicationBuilder.Build(),
+			testFunctionBuilder.Build(),
 		},
 	}, {
 		Name: "ignore other configmaps in the correct namespace",
@@ -90,9 +90,9 @@ func TestClusterBuildersReconciler(t *testing.T) {
 		GivenObjects: []runtime.Object{
 			testBuilders.
 				NamespaceName(testNamespace, "not-builders").
-				Get(),
-			testApplicationBuilder.Get(),
-			testFunctionBuilder.Get(),
+				Build(),
+			testApplicationBuilder.Build(),
+			testFunctionBuilder.Build(),
 		},
 	}, {
 		Name: "ignore other configmaps in the wrong namespace",
@@ -100,35 +100,35 @@ func TestClusterBuildersReconciler(t *testing.T) {
 		GivenObjects: []runtime.Object{
 			testBuilders.
 				NamespaceName("not-riff-system", testName).
-				Get(),
-			testApplicationBuilder.Get(),
-			testFunctionBuilder.Get(),
+				Build(),
+			testApplicationBuilder.Build(),
+			testFunctionBuilder.Build(),
 		},
 	}, {
 		Name: "create builders configmap, not ready",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			testApplicationBuilder.Get(),
-			testFunctionBuilder.Get(),
+			testApplicationBuilder.Build(),
+			testFunctionBuilder.Build(),
 		},
 		ExpectCreates: []runtime.Object{
 			testBuilders.
 				AddData("riff-application", "").
 				AddData("riff-function", "").
-				Get(),
+				Build(),
 		},
 	}, {
 		Name: "create builders configmap, ready",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			testApplicationBuilderReady.Get(),
-			testFunctionBuilderReady.Get(),
+			testApplicationBuilderReady.Build(),
+			testFunctionBuilderReady.Build(),
 		},
 		ExpectCreates: []runtime.Object{
 			testBuilders.
 				AddData("riff-application", testApplicationImage).
 				AddData("riff-function", testFunctionImage).
-				Get(),
+				Build(),
 		},
 	}, {
 		Name: "create builders configmap, error",
@@ -137,29 +137,29 @@ func TestClusterBuildersReconciler(t *testing.T) {
 			rtesting.InduceFailure("create", "ConfigMap"),
 		},
 		GivenObjects: []runtime.Object{
-			testApplicationBuilder.Get(),
-			testFunctionBuilder.Get(),
+			testApplicationBuilder.Build(),
+			testFunctionBuilder.Build(),
 		},
 		ShouldErr: true,
 		ExpectCreates: []runtime.Object{
 			testBuilders.
 				AddData("riff-application", "").
 				AddData("riff-function", "").
-				Get(),
+				Build(),
 		},
 	}, {
 		Name: "update builders configmap",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			testBuilders.Get(),
-			testApplicationBuilderReady.Get(),
-			testFunctionBuilderReady.Get(),
+			testBuilders.Build(),
+			testApplicationBuilderReady.Build(),
+			testFunctionBuilderReady.Build(),
 		},
 		ExpectUpdates: []runtime.Object{
 			testBuilders.
 				AddData("riff-application", testApplicationImage).
 				AddData("riff-function", testFunctionImage).
-				Get(),
+				Build(),
 		},
 	}, {
 		Name: "update builders configmap, error",
@@ -168,16 +168,16 @@ func TestClusterBuildersReconciler(t *testing.T) {
 			rtesting.InduceFailure("update", "ConfigMap"),
 		},
 		GivenObjects: []runtime.Object{
-			testBuilders.Get(),
-			testApplicationBuilderReady.Get(),
-			testFunctionBuilderReady.Get(),
+			testBuilders.Build(),
+			testApplicationBuilderReady.Build(),
+			testFunctionBuilderReady.Build(),
 		},
 		ShouldErr: true,
 		ExpectUpdates: []runtime.Object{
 			testBuilders.
 				AddData("riff-application", testApplicationImage).
 				AddData("riff-function", testFunctionImage).
-				Get(),
+				Build(),
 		},
 	}, {
 		Name: "get builders configmap error",
@@ -186,9 +186,9 @@ func TestClusterBuildersReconciler(t *testing.T) {
 			rtesting.InduceFailure("get", "ConfigMap"),
 		},
 		GivenObjects: []runtime.Object{
-			testBuilders.Get(),
-			testApplicationBuilder.Get(),
-			testFunctionBuilder.Get(),
+			testBuilders.Build(),
+			testApplicationBuilder.Build(),
+			testFunctionBuilder.Build(),
 		},
 		ShouldErr: true,
 	}, {
@@ -198,9 +198,9 @@ func TestClusterBuildersReconciler(t *testing.T) {
 			rtesting.InduceFailure("list", "ClusterBuilderList"),
 		},
 		GivenObjects: []runtime.Object{
-			testBuilders.Get(),
-			testApplicationBuilder.Get(),
-			testFunctionBuilder.Get(),
+			testBuilders.Build(),
+			testApplicationBuilder.Build(),
+			testFunctionBuilder.Build(),
 		},
 		ShouldErr: true,
 	}}

--- a/pkg/controllers/build/container_controller_test.go
+++ b/pkg/controllers/build/container_controller_test.go
@@ -30,7 +30,7 @@ import (
 	kpackbuildv1alpha1 "github.com/projectriff/system/pkg/apis/thirdparty/kpack/build/v1alpha1"
 	"github.com/projectriff/system/pkg/controllers/build"
 	rtesting "github.com/projectriff/system/pkg/controllers/testing"
-	"github.com/projectriff/system/pkg/controllers/testing/factories"
+	"github.com/projectriff/system/pkg/controllers/testing/builders"
 	"github.com/projectriff/system/pkg/tracker"
 )
 
@@ -41,24 +41,24 @@ func TestContainerReconciler(t *testing.T) {
 	testImagePrefix := "example.com/repo"
 	testSha256 := "cf8b4c69d5460f88530e1c80b8856a70801f31c50b191c8413043ba9b160a43e"
 
-	containerConditionImageResolved := factories.Condition().Type(buildv1alpha1.ContainerConditionImageResolved)
-	containerConditionReady := factories.Condition().Type(buildv1alpha1.ContainerConditionReady)
+	containerConditionImageResolved := builders.Condition().Type(buildv1alpha1.ContainerConditionImageResolved)
+	containerConditionReady := builders.Condition().Type(buildv1alpha1.ContainerConditionReady)
 
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = kpackbuildv1alpha1.AddToScheme(scheme)
 	_ = buildv1alpha1.AddToScheme(scheme)
 
-	containerMinimal := factories.Container().
+	containerMinimal := builders.Container().
 		NamespaceName(testNamespace, testName)
 	containerValid := containerMinimal.
 		Image("%s/%s", testImagePrefix, testName)
 
-	cmImagePrefix := factories.ConfigMap().
+	cmImagePrefix := builders.ConfigMap().
 		NamespaceName(testNamespace, "riff-build").
 		AddData("default-image-prefix", "")
 
-	serviceAccount := factories.ServiceAccount().
+	serviceAccount := builders.ServiceAccount().
 		NamespaceName(testNamespace, "riff-build")
 
 	table := rtesting.Table{{
@@ -69,7 +69,7 @@ func TestContainerReconciler(t *testing.T) {
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
 			containerValid.
-				ObjectMeta(func(om factories.ObjectMeta) {
+				ObjectMeta(func(om builders.ObjectMeta) {
 					om.Deleted(1)
 				}).
 				Get(),
@@ -81,7 +81,7 @@ func TestContainerReconciler(t *testing.T) {
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
 			containerValid.Get(),
-			serviceAccount.Get(),
+			serviceAccount.Build(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
 			containerMinimal.
@@ -108,9 +108,9 @@ func TestContainerReconciler(t *testing.T) {
 		GivenObjects: []runtime.Object{
 			cmImagePrefix.
 				AddData("default-image-prefix", testImagePrefix).
-				Get(),
+				Build(),
 			containerMinimal.Get(),
-			serviceAccount.Get(),
+			serviceAccount.Build(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
 			containerMinimal.
@@ -140,7 +140,7 @@ func TestContainerReconciler(t *testing.T) {
 		Name: "default image, undefined",
 		Key:  testKey,
 		GivenObjects: []runtime.Object{
-			cmImagePrefix.Get(),
+			cmImagePrefix.Build(),
 			containerMinimal.Get(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
@@ -159,7 +159,7 @@ func TestContainerReconciler(t *testing.T) {
 			rtesting.InduceFailure("get", "ConfigMap"),
 		},
 		GivenObjects: []runtime.Object{
-			cmImagePrefix.Get(),
+			cmImagePrefix.Build(),
 			containerMinimal.Get(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
@@ -181,7 +181,7 @@ func TestContainerReconciler(t *testing.T) {
 		},
 		GivenObjects: []runtime.Object{
 			containerValid.Get(),
-			serviceAccount.Get(),
+			serviceAccount.Build(),
 		},
 		ExpectStatusUpdates: []runtime.Object{
 			containerMinimal.

--- a/pkg/controllers/testing/builders/adapter_knative.go
+++ b/pkg/controllers/testing/builders/adapter_knative.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package factories
+package builders
 
 import (
 	"fmt"
@@ -42,93 +42,93 @@ func AdapterKnative(seed ...*knativev1alpha1.Adapter) *adapterKnative {
 	}
 }
 
-func (f *adapterKnative) deepCopy() *adapterKnative {
-	return AdapterKnative(f.target.DeepCopy())
+func (b *adapterKnative) deepCopy() *adapterKnative {
+	return AdapterKnative(b.target.DeepCopy())
 }
 
-func (f *adapterKnative) Get() *knativev1alpha1.Adapter {
-	return f.deepCopy().target
+func (b *adapterKnative) Build() *knativev1alpha1.Adapter {
+	return b.deepCopy().target
 }
 
-func (f *adapterKnative) Mutate(m func(*knativev1alpha1.Adapter)) *adapterKnative {
-	f = f.deepCopy()
-	m(f.target)
-	return f
+func (b *adapterKnative) Mutate(m func(*knativev1alpha1.Adapter)) *adapterKnative {
+	b = b.deepCopy()
+	m(b.target)
+	return b
 }
 
-func (f *adapterKnative) NamespaceName(namespace, name string) *adapterKnative {
-	return f.Mutate(func(adapter *knativev1alpha1.Adapter) {
+func (b *adapterKnative) NamespaceName(namespace, name string) *adapterKnative {
+	return b.Mutate(func(adapter *knativev1alpha1.Adapter) {
 		adapter.ObjectMeta.Namespace = namespace
 		adapter.ObjectMeta.Name = name
 	})
 }
 
-func (f *adapterKnative) ObjectMeta(nf func(ObjectMeta)) *adapterKnative {
-	return f.Mutate(func(adapter *knativev1alpha1.Adapter) {
+func (b *adapterKnative) ObjectMeta(nf func(ObjectMeta)) *adapterKnative {
+	return b.Mutate(func(adapter *knativev1alpha1.Adapter) {
 		omf := objectMeta(adapter.ObjectMeta)
 		nf(omf)
-		adapter.ObjectMeta = omf.Get()
+		adapter.ObjectMeta = omf.Build()
 	})
 }
 
-func (f *adapterKnative) ApplicationRef(format string, a ...interface{}) *adapterKnative {
-	return f.Mutate(func(adapter *knativev1alpha1.Adapter) {
+func (b *adapterKnative) ApplicationRef(format string, a ...interface{}) *adapterKnative {
+	return b.Mutate(func(adapter *knativev1alpha1.Adapter) {
 		adapter.Spec.Build = knativev1alpha1.Build{
 			ApplicationRef: fmt.Sprintf(format, a...),
 		}
 	})
 }
 
-func (f *adapterKnative) ContainerRef(format string, a ...interface{}) *adapterKnative {
-	return f.Mutate(func(adapter *knativev1alpha1.Adapter) {
+func (b *adapterKnative) ContainerRef(format string, a ...interface{}) *adapterKnative {
+	return b.Mutate(func(adapter *knativev1alpha1.Adapter) {
 		adapter.Spec.Build = knativev1alpha1.Build{
 			ContainerRef: fmt.Sprintf(format, a...),
 		}
 	})
 }
 
-func (f *adapterKnative) FunctionRef(format string, a ...interface{}) *adapterKnative {
-	return f.Mutate(func(adapter *knativev1alpha1.Adapter) {
+func (b *adapterKnative) FunctionRef(format string, a ...interface{}) *adapterKnative {
+	return b.Mutate(func(adapter *knativev1alpha1.Adapter) {
 		adapter.Spec.Build = knativev1alpha1.Build{
 			FunctionRef: fmt.Sprintf(format, a...),
 		}
 	})
 }
 
-func (f *adapterKnative) ConfigurationRef(format string, a ...interface{}) *adapterKnative {
-	return f.Mutate(func(adapter *knativev1alpha1.Adapter) {
+func (b *adapterKnative) ConfigurationRef(format string, a ...interface{}) *adapterKnative {
+	return b.Mutate(func(adapter *knativev1alpha1.Adapter) {
 		adapter.Spec.Target = knativev1alpha1.AdapterTarget{
 			ConfigurationRef: fmt.Sprintf(format, a...),
 		}
 	})
 }
 
-func (f *adapterKnative) ServiceRef(format string, a ...interface{}) *adapterKnative {
-	return f.Mutate(func(adapter *knativev1alpha1.Adapter) {
+func (b *adapterKnative) ServiceRef(format string, a ...interface{}) *adapterKnative {
+	return b.Mutate(func(adapter *knativev1alpha1.Adapter) {
 		adapter.Spec.Target = knativev1alpha1.AdapterTarget{
 			ServiceRef: fmt.Sprintf(format, a...),
 		}
 	})
 }
 
-func (f *adapterKnative) StatusConditions(conditions ...*condition) *adapterKnative {
-	return f.Mutate(func(adapter *knativev1alpha1.Adapter) {
+func (b *adapterKnative) StatusConditions(conditions ...*condition) *adapterKnative {
+	return b.Mutate(func(adapter *knativev1alpha1.Adapter) {
 		c := make([]apis.Condition, len(conditions))
 		for i, cg := range conditions {
-			c[i] = cg.Get()
+			c[i] = cg.Build()
 		}
 		adapter.Status.Conditions = c
 	})
 }
 
-func (f *adapterKnative) StatusObservedGeneration(generation int64) *adapterKnative {
-	return f.Mutate(func(adapter *knativev1alpha1.Adapter) {
+func (b *adapterKnative) StatusObservedGeneration(generation int64) *adapterKnative {
+	return b.Mutate(func(adapter *knativev1alpha1.Adapter) {
 		adapter.Status.ObservedGeneration = generation
 	})
 }
 
-func (f *adapterKnative) StatusLatestImage(format string, a ...interface{}) *adapterKnative {
-	return f.Mutate(func(adapter *knativev1alpha1.Adapter) {
+func (b *adapterKnative) StatusLatestImage(format string, a ...interface{}) *adapterKnative {
+	return b.Mutate(func(adapter *knativev1alpha1.Adapter) {
 		adapter.Status.LatestImage = fmt.Sprintf(format, a...)
 	})
 }

--- a/pkg/controllers/testing/builders/application.go
+++ b/pkg/controllers/testing/builders/application.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package factories
+package builders
 
 import (
 	"fmt"
@@ -46,43 +46,43 @@ func Application(seed ...*buildv1alpha1.Application) *application {
 	}
 }
 
-func (f *application) deepCopy() *application {
-	return Application(f.target.DeepCopy())
+func (b *application) deepCopy() *application {
+	return Application(b.target.DeepCopy())
 }
 
-func (f *application) Get() *buildv1alpha1.Application {
-	return f.deepCopy().target
+func (b *application) Build() *buildv1alpha1.Application {
+	return b.deepCopy().target
 }
 
-func (f *application) Mutate(m func(*buildv1alpha1.Application)) *application {
-	f = f.deepCopy()
-	m(f.target)
-	return f
+func (b *application) Mutate(m func(*buildv1alpha1.Application)) *application {
+	b = b.deepCopy()
+	m(b.target)
+	return b
 }
 
-func (f *application) NamespaceName(namespace, name string) *application {
-	return f.Mutate(func(app *buildv1alpha1.Application) {
+func (b *application) NamespaceName(namespace, name string) *application {
+	return b.Mutate(func(app *buildv1alpha1.Application) {
 		app.ObjectMeta.Namespace = namespace
 		app.ObjectMeta.Name = name
 	})
 }
 
-func (f *application) ObjectMeta(nf func(ObjectMeta)) *application {
-	return f.Mutate(func(app *buildv1alpha1.Application) {
+func (b *application) ObjectMeta(nf func(ObjectMeta)) *application {
+	return b.Mutate(func(app *buildv1alpha1.Application) {
 		omf := objectMeta(app.ObjectMeta)
 		nf(omf)
-		app.ObjectMeta = omf.Get()
+		app.ObjectMeta = omf.Build()
 	})
 }
 
-func (f *application) Image(format string, a ...interface{}) *application {
-	return f.Mutate(func(app *buildv1alpha1.Application) {
+func (b *application) Image(format string, a ...interface{}) *application {
+	return b.Mutate(func(app *buildv1alpha1.Application) {
 		app.Spec.Image = fmt.Sprintf(format, a...)
 	})
 }
 
-func (f *application) SourceGit(url string, revision string) *application {
-	return f.Mutate(func(app *buildv1alpha1.Application) {
+func (b *application) SourceGit(url string, revision string) *application {
+	return b.Mutate(func(app *buildv1alpha1.Application) {
 		if app.Spec.Source == nil {
 			app.Spec.Source = &buildv1alpha1.Source{}
 		}
@@ -96,8 +96,8 @@ func (f *application) SourceGit(url string, revision string) *application {
 	})
 }
 
-func (f *application) SourceSubPath(subpath string) *application {
-	return f.Mutate(func(app *buildv1alpha1.Application) {
+func (b *application) SourceSubPath(subpath string) *application {
+	return b.Mutate(func(app *buildv1alpha1.Application) {
 		if app.Spec.Source == nil {
 			app.Spec.Source = &buildv1alpha1.Source{}
 		}
@@ -105,8 +105,8 @@ func (f *application) SourceSubPath(subpath string) *application {
 	})
 }
 
-func (f *application) BuildCache(quantity string) *application {
-	return f.Mutate(func(app *buildv1alpha1.Application) {
+func (b *application) BuildCache(quantity string) *application {
+	return b.Mutate(func(app *buildv1alpha1.Application) {
 		size, err := resource.ParseQuantity(quantity)
 		if err != nil {
 			panic(err)
@@ -115,30 +115,30 @@ func (f *application) BuildCache(quantity string) *application {
 	})
 }
 
-func (f *application) StatusConditions(conditions ...*condition) *application {
-	return f.Mutate(func(app *buildv1alpha1.Application) {
+func (b *application) StatusConditions(conditions ...*condition) *application {
+	return b.Mutate(func(app *buildv1alpha1.Application) {
 		c := make([]apis.Condition, len(conditions))
 		for i, cg := range conditions {
-			c[i] = cg.Get()
+			c[i] = cg.Build()
 		}
 		app.Status.Conditions = c
 	})
 }
 
-func (f *application) StatusReady() *application {
-	return f.StatusConditions(
+func (b *application) StatusReady() *application {
+	return b.StatusConditions(
 		Condition().Type(buildv1alpha1.ApplicationConditionReady).True(),
 	)
 }
 
-func (f *application) StatusObservedGeneration(generation int64) *application {
-	return f.Mutate(func(app *buildv1alpha1.Application) {
+func (b *application) StatusObservedGeneration(generation int64) *application {
+	return b.Mutate(func(app *buildv1alpha1.Application) {
 		app.Status.ObservedGeneration = generation
 	})
 }
 
-func (f *application) StatusKpackImageRef(format string, a ...interface{}) *application {
-	return f.Mutate(func(app *buildv1alpha1.Application) {
+func (b *application) StatusKpackImageRef(format string, a ...interface{}) *application {
+	return b.Mutate(func(app *buildv1alpha1.Application) {
 		app.Status.KpackImageRef = &refs.TypedLocalObjectReference{
 			APIGroup: rtesting.StringPtr("build.pivotal.io"),
 			Kind:     "Image",
@@ -147,8 +147,8 @@ func (f *application) StatusKpackImageRef(format string, a ...interface{}) *appl
 	})
 }
 
-func (f *application) StatusBuildCacheRef(format string, a ...interface{}) *application {
-	return f.Mutate(func(app *buildv1alpha1.Application) {
+func (b *application) StatusBuildCacheRef(format string, a ...interface{}) *application {
+	return b.Mutate(func(app *buildv1alpha1.Application) {
 		app.Status.BuildCacheRef = &refs.TypedLocalObjectReference{
 			Kind: "PersistentVolumeClaim",
 			Name: fmt.Sprintf(format, a...),
@@ -156,14 +156,14 @@ func (f *application) StatusBuildCacheRef(format string, a ...interface{}) *appl
 	})
 }
 
-func (f *application) StatusTargetImage(format string, a ...interface{}) *application {
-	return f.Mutate(func(app *buildv1alpha1.Application) {
+func (b *application) StatusTargetImage(format string, a ...interface{}) *application {
+	return b.Mutate(func(app *buildv1alpha1.Application) {
 		app.Status.TargetImage = fmt.Sprintf(format, a...)
 	})
 }
 
-func (f *application) StatusLatestImage(format string, a ...interface{}) *application {
-	return f.Mutate(func(app *buildv1alpha1.Application) {
+func (b *application) StatusLatestImage(format string, a ...interface{}) *application {
+	return b.Mutate(func(app *buildv1alpha1.Application) {
 		app.Status.LatestImage = fmt.Sprintf(format, a...)
 	})
 }

--- a/pkg/controllers/testing/builders/condition.go
+++ b/pkg/controllers/testing/builders/condition.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package factories
+package builders
 
 import (
 	"fmt"
@@ -43,67 +43,67 @@ func Condition(seed ...apis.Condition) *condition {
 	}
 }
 
-func (f *condition) deepCopy() *condition {
-	return Condition(*f.target.DeepCopy())
+func (b *condition) deepCopy() *condition {
+	return Condition(*b.target.DeepCopy())
 }
 
-func (f *condition) Get() apis.Condition {
-	return *f.deepCopy().target
+func (b *condition) Build() apis.Condition {
+	return *b.deepCopy().target
 }
 
-func (f *condition) Mutate(m func(*apis.Condition)) *condition {
-	f = f.deepCopy()
-	m(f.target)
-	return f
+func (b *condition) Mutate(m func(*apis.Condition)) *condition {
+	b = b.deepCopy()
+	m(b.target)
+	return b
 }
 
-func (f *condition) Type(t apis.ConditionType) *condition {
-	return f.Mutate(func(c *apis.Condition) {
+func (b *condition) Type(t apis.ConditionType) *condition {
+	return b.Mutate(func(c *apis.Condition) {
 		c.Type = t
 	})
 }
 
-func (f *condition) Unknown() *condition {
-	return f.Mutate(func(c *apis.Condition) {
+func (b *condition) Unknown() *condition {
+	return b.Mutate(func(c *apis.Condition) {
 		c.Status = corev1.ConditionUnknown
 	})
 }
 
-func (f *condition) True() *condition {
-	return f.Mutate(func(c *apis.Condition) {
+func (b *condition) True() *condition {
+	return b.Mutate(func(c *apis.Condition) {
 		c.Status = corev1.ConditionTrue
 		c.Reason = ""
 		c.Message = ""
 	})
 }
 
-func (f *condition) False() *condition {
-	return f.Mutate(func(c *apis.Condition) {
+func (b *condition) False() *condition {
+	return b.Mutate(func(c *apis.Condition) {
 		c.Status = corev1.ConditionFalse
 	})
 }
 
-func (f *condition) Reason(reason, message string) *condition {
-	return f.Mutate(func(c *apis.Condition) {
+func (b *condition) Reason(reason, message string) *condition {
+	return b.Mutate(func(c *apis.Condition) {
 		c.Reason = reason
 		c.Message = message
 	})
 }
 
-func (f *condition) Info() *condition {
-	return f.Mutate(func(c *apis.Condition) {
+func (b *condition) Info() *condition {
+	return b.Mutate(func(c *apis.Condition) {
 		c.Severity = apis.ConditionSeverityInfo
 	})
 }
 
-func (f *condition) Warning() *condition {
-	return f.Mutate(func(c *apis.Condition) {
+func (b *condition) Warning() *condition {
+	return b.Mutate(func(c *apis.Condition) {
 		c.Severity = apis.ConditionSeverityWarning
 	})
 }
 
-func (f *condition) Error() *condition {
-	return f.Mutate(func(c *apis.Condition) {
+func (b *condition) Error() *condition {
+	return b.Mutate(func(c *apis.Condition) {
 		c.Severity = apis.ConditionSeverityError
 	})
 }

--- a/pkg/controllers/testing/builders/configmap.go
+++ b/pkg/controllers/testing/builders/configmap.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package factories
+package builders
 
 import (
 	"fmt"
@@ -41,37 +41,37 @@ func ConfigMap(seed ...*corev1.ConfigMap) *configMap {
 	}
 }
 
-func (f *configMap) deepCopy() *configMap {
-	return ConfigMap(f.target.DeepCopy())
+func (b *configMap) deepCopy() *configMap {
+	return ConfigMap(b.target.DeepCopy())
 }
 
-func (f *configMap) Get() *corev1.ConfigMap {
-	return f.deepCopy().target
+func (b *configMap) Build() *corev1.ConfigMap {
+	return b.deepCopy().target
 }
 
-func (f *configMap) Mutate(m func(*corev1.ConfigMap)) *configMap {
-	f = f.deepCopy()
-	m(f.target)
-	return f
+func (b *configMap) Mutate(m func(*corev1.ConfigMap)) *configMap {
+	b = b.deepCopy()
+	m(b.target)
+	return b
 }
 
-func (f *configMap) NamespaceName(namespace, name string) *configMap {
-	return f.Mutate(func(cm *corev1.ConfigMap) {
+func (b *configMap) NamespaceName(namespace, name string) *configMap {
+	return b.Mutate(func(cm *corev1.ConfigMap) {
 		cm.ObjectMeta.Namespace = namespace
 		cm.ObjectMeta.Name = name
 	})
 }
 
-func (f *configMap) ObjectMeta(nf func(ObjectMeta)) *configMap {
-	return f.Mutate(func(cm *corev1.ConfigMap) {
+func (b *configMap) ObjectMeta(nf func(ObjectMeta)) *configMap {
+	return b.Mutate(func(cm *corev1.ConfigMap) {
 		omf := objectMeta(cm.ObjectMeta)
 		nf(omf)
-		cm.ObjectMeta = omf.Get()
+		cm.ObjectMeta = omf.Build()
 	})
 }
 
-func (f *configMap) AddData(key, value string) *configMap {
-	return f.Mutate(func(cm *corev1.ConfigMap) {
+func (b *configMap) AddData(key, value string) *configMap {
+	return b.Mutate(func(cm *corev1.ConfigMap) {
 		if cm.Data == nil {
 			cm.Data = map[string]string{}
 		}

--- a/pkg/controllers/testing/builders/container.go
+++ b/pkg/controllers/testing/builders/container.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package factories
+package builders
 
 import (
 	"fmt"
@@ -42,71 +42,71 @@ func Container(seed ...*buildv1alpha1.Container) *container {
 	}
 }
 
-func (f *container) deepCopy() *container {
-	return Container(f.target.DeepCopy())
+func (b *container) deepCopy() *container {
+	return Container(b.target.DeepCopy())
 }
 
-func (f *container) Get() *buildv1alpha1.Container {
-	return f.deepCopy().target
+func (b *container) Get() *buildv1alpha1.Container {
+	return b.deepCopy().target
 }
 
-func (f *container) Mutate(m func(*buildv1alpha1.Container)) *container {
-	f = f.deepCopy()
-	m(f.target)
-	return f
+func (b *container) Mutate(m func(*buildv1alpha1.Container)) *container {
+	b = b.deepCopy()
+	m(b.target)
+	return b
 }
 
-func (f *container) NamespaceName(namespace, name string) *container {
-	return f.Mutate(func(con *buildv1alpha1.Container) {
+func (b *container) NamespaceName(namespace, name string) *container {
+	return b.Mutate(func(con *buildv1alpha1.Container) {
 		con.ObjectMeta.Namespace = namespace
 		con.ObjectMeta.Name = name
 	})
 }
 
-func (f *container) ObjectMeta(nf func(ObjectMeta)) *container {
-	return f.Mutate(func(con *buildv1alpha1.Container) {
+func (b *container) ObjectMeta(nf func(ObjectMeta)) *container {
+	return b.Mutate(func(con *buildv1alpha1.Container) {
 		omf := objectMeta(con.ObjectMeta)
 		nf(omf)
-		con.ObjectMeta = omf.Get()
+		con.ObjectMeta = omf.Build()
 	})
 }
 
-func (f *container) Image(format string, a ...interface{}) *container {
-	return f.Mutate(func(con *buildv1alpha1.Container) {
+func (b *container) Image(format string, a ...interface{}) *container {
+	return b.Mutate(func(con *buildv1alpha1.Container) {
 		con.Spec.Image = fmt.Sprintf(format, a...)
 	})
 }
 
-func (f *container) StatusConditions(conditions ...*condition) *container {
-	return f.Mutate(func(con *buildv1alpha1.Container) {
+func (b *container) StatusConditions(conditions ...*condition) *container {
+	return b.Mutate(func(con *buildv1alpha1.Container) {
 		c := make([]apis.Condition, len(conditions))
 		for i, cg := range conditions {
-			c[i] = cg.Get()
+			c[i] = cg.Build()
 		}
 		con.Status.Conditions = c
 	})
 }
 
-func (f *container) StatusReady() *container {
-	return f.StatusConditions(
+func (b *container) StatusReady() *container {
+	return b.StatusConditions(
 		Condition().Type(buildv1alpha1.ContainerConditionReady).True(),
 	)
 }
 
-func (f *container) StatusObservedGeneration(generation int64) *container {
-	return f.Mutate(func(con *buildv1alpha1.Container) {
+func (b *container) StatusObservedGeneration(generation int64) *container {
+	return b.Mutate(func(con *buildv1alpha1.Container) {
 		con.Status.ObservedGeneration = generation
 	})
 }
 
-func (f *container) StatusTargetImage(format string, a ...interface{}) *container {
-	return f.Mutate(func(con *buildv1alpha1.Container) {
+func (b *container) StatusTargetImage(format string, a ...interface{}) *container {
+	return b.Mutate(func(con *buildv1alpha1.Container) {
 		con.Status.TargetImage = fmt.Sprintf(format, a...)
 	})
 }
 
-func (f *container) StatusLatestImage(format string, a ...interface{}) *container {
-	return f.Mutate(func(con *buildv1alpha1.Container) {
+func (b *container) StatusLatestImage(format string, a ...interface{}) *container {
+	return b.Mutate(func(con *buildv1alpha1.Container) {
 		con.Status.LatestImage = fmt.Sprintf(format, a...)
 	})
 }

--- a/pkg/controllers/testing/builders/deployer_knative.go
+++ b/pkg/controllers/testing/builders/deployer_knative.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package factories
+package builders
 
 import (
 	"fmt"
@@ -46,121 +46,121 @@ func DeployerKnative(seed ...*knativev1alpha1.Deployer) *deployerKnative {
 	}
 }
 
-func (f *deployerKnative) deepCopy() *deployerKnative {
-	return DeployerKnative(f.target.DeepCopy())
+func (b *deployerKnative) deepCopy() *deployerKnative {
+	return DeployerKnative(b.target.DeepCopy())
 }
 
-func (f *deployerKnative) Get() *knativev1alpha1.Deployer {
-	return f.deepCopy().target
+func (b *deployerKnative) Build() *knativev1alpha1.Deployer {
+	return b.deepCopy().target
 }
 
-func (f *deployerKnative) Mutate(m func(*knativev1alpha1.Deployer)) *deployerKnative {
-	f = f.deepCopy()
-	m(f.target)
-	return f
+func (b *deployerKnative) Mutate(m func(*knativev1alpha1.Deployer)) *deployerKnative {
+	b = b.deepCopy()
+	m(b.target)
+	return b
 }
 
-func (f *deployerKnative) NamespaceName(namespace, name string) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+func (b *deployerKnative) NamespaceName(namespace, name string) *deployerKnative {
+	return b.Mutate(func(deployer *knativev1alpha1.Deployer) {
 		deployer.ObjectMeta.Namespace = namespace
 		deployer.ObjectMeta.Name = name
 	})
 }
 
-func (f *deployerKnative) ObjectMeta(nf func(ObjectMeta)) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+func (b *deployerKnative) ObjectMeta(nf func(ObjectMeta)) *deployerKnative {
+	return b.Mutate(func(deployer *knativev1alpha1.Deployer) {
 		omf := objectMeta(deployer.ObjectMeta)
 		nf(omf)
-		deployer.ObjectMeta = omf.Get()
+		deployer.ObjectMeta = omf.Build()
 	})
 }
 
-func (f *deployerKnative) PodTemplateSpec(nf func(PodTemplateSpec)) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+func (b *deployerKnative) PodTemplateSpec(nf func(PodTemplateSpec)) *deployerKnative {
+	return b.Mutate(func(deployer *knativev1alpha1.Deployer) {
 		if deployer.Spec.Template == nil {
 			deployer.Spec.Template = &corev1.PodTemplateSpec{}
 		}
 		ptsf := podTemplateSpec(*deployer.Spec.Template)
 		nf(ptsf)
-		pts := ptsf.Get()
+		pts := ptsf.Build()
 		deployer.Spec.Template = &pts
 	})
 }
 
-func (f *deployerKnative) ApplicationRef(format string, a ...interface{}) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+func (b *deployerKnative) ApplicationRef(format string, a ...interface{}) *deployerKnative {
+	return b.Mutate(func(deployer *knativev1alpha1.Deployer) {
 		deployer.Spec.Build = &knativev1alpha1.Build{
 			ApplicationRef: fmt.Sprintf(format, a...),
 		}
 	})
 }
 
-func (f *deployerKnative) ContainerRef(format string, a ...interface{}) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+func (b *deployerKnative) ContainerRef(format string, a ...interface{}) *deployerKnative {
+	return b.Mutate(func(deployer *knativev1alpha1.Deployer) {
 		deployer.Spec.Build = &knativev1alpha1.Build{
 			ContainerRef: fmt.Sprintf(format, a...),
 		}
 	})
 }
 
-func (f *deployerKnative) FunctionRef(format string, a ...interface{}) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+func (b *deployerKnative) FunctionRef(format string, a ...interface{}) *deployerKnative {
+	return b.Mutate(func(deployer *knativev1alpha1.Deployer) {
 		deployer.Spec.Build = &knativev1alpha1.Build{
 			FunctionRef: fmt.Sprintf(format, a...),
 		}
 	})
 }
 
-func (f *deployerKnative) Image(format string, a ...interface{}) *deployerKnative {
-	return f.PodTemplateSpec(func(ptsf PodTemplateSpec) {
+func (b *deployerKnative) Image(format string, a ...interface{}) *deployerKnative {
+	return b.PodTemplateSpec(func(ptsf PodTemplateSpec) {
 		ptsf.ContainerNamed("user-container", func(container *corev1.Container) {
 			container.Image = fmt.Sprintf(format, a...)
 		})
 	})
 }
 
-func (f *deployerKnative) IngressPolicy(policy knativev1alpha1.IngressPolicy) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+func (b *deployerKnative) IngressPolicy(policy knativev1alpha1.IngressPolicy) *deployerKnative {
+	return b.Mutate(func(deployer *knativev1alpha1.Deployer) {
 		deployer.Spec.IngressPolicy = policy
 	})
 }
 
-func (f *deployerKnative) MinScale(scale int32) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+func (b *deployerKnative) MinScale(scale int32) *deployerKnative {
+	return b.Mutate(func(deployer *knativev1alpha1.Deployer) {
 		deployer.Spec.Scale.Min = &scale
 	})
 }
 
-func (f *deployerKnative) MaxScale(scale int32) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+func (b *deployerKnative) MaxScale(scale int32) *deployerKnative {
+	return b.Mutate(func(deployer *knativev1alpha1.Deployer) {
 		deployer.Spec.Scale.Max = &scale
 	})
 }
 
-func (f *deployerKnative) StatusConditions(conditions ...*condition) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+func (b *deployerKnative) StatusConditions(conditions ...*condition) *deployerKnative {
+	return b.Mutate(func(deployer *knativev1alpha1.Deployer) {
 		c := make([]apis.Condition, len(conditions))
 		for i, cg := range conditions {
-			c[i] = cg.Get()
+			c[i] = cg.Build()
 		}
 		deployer.Status.Conditions = c
 	})
 }
 
-func (f *deployerKnative) StatusObservedGeneration(generation int64) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+func (b *deployerKnative) StatusObservedGeneration(generation int64) *deployerKnative {
+	return b.Mutate(func(deployer *knativev1alpha1.Deployer) {
 		deployer.Status.ObservedGeneration = generation
 	})
 }
 
-func (f *deployerKnative) StatusLatestImage(format string, a ...interface{}) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+func (b *deployerKnative) StatusLatestImage(format string, a ...interface{}) *deployerKnative {
+	return b.Mutate(func(deployer *knativev1alpha1.Deployer) {
 		deployer.Status.LatestImage = fmt.Sprintf(format, a...)
 	})
 }
 
-func (f *deployerKnative) StatusConfigurationRef(format string, a ...interface{}) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+func (b *deployerKnative) StatusConfigurationRef(format string, a ...interface{}) *deployerKnative {
+	return b.Mutate(func(deployer *knativev1alpha1.Deployer) {
 		deployer.Status.ConfigurationRef = &refs.TypedLocalObjectReference{
 			APIGroup: rtesting.StringPtr("serving.knative.dev"),
 			Kind:     "Configuration",
@@ -169,8 +169,8 @@ func (f *deployerKnative) StatusConfigurationRef(format string, a ...interface{}
 	})
 }
 
-func (f *deployerKnative) StatusRouteRef(format string, a ...interface{}) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+func (b *deployerKnative) StatusRouteRef(format string, a ...interface{}) *deployerKnative {
+	return b.Mutate(func(deployer *knativev1alpha1.Deployer) {
 		deployer.Status.RouteRef = &refs.TypedLocalObjectReference{
 			APIGroup: rtesting.StringPtr("serving.knative.dev"),
 			Kind:     "Route",
@@ -179,16 +179,16 @@ func (f *deployerKnative) StatusRouteRef(format string, a ...interface{}) *deplo
 	})
 }
 
-func (f *deployerKnative) StatusAddressURL(url string) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+func (b *deployerKnative) StatusAddressURL(url string) *deployerKnative {
+	return b.Mutate(func(deployer *knativev1alpha1.Deployer) {
 		deployer.Status.Address = &apis.Addressable{
 			URL: url,
 		}
 	})
 }
 
-func (f *deployerKnative) StatusURL(url string) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+func (b *deployerKnative) StatusURL(url string) *deployerKnative {
+	return b.Mutate(func(deployer *knativev1alpha1.Deployer) {
 		deployer.Status.URL = url
 	})
 }

--- a/pkg/controllers/testing/builders/function.go
+++ b/pkg/controllers/testing/builders/function.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package factories
+package builders
 
 import (
 	"fmt"
@@ -46,61 +46,61 @@ func Function(seed ...*buildv1alpha1.Function) *function {
 	}
 }
 
-func (f *function) deepCopy() *function {
-	return Function(f.target.DeepCopy())
+func (b *function) deepCopy() *function {
+	return Function(b.target.DeepCopy())
 }
 
-func (f *function) Get() *buildv1alpha1.Function {
-	return f.deepCopy().target
+func (b *function) Build() *buildv1alpha1.Function {
+	return b.deepCopy().target
 }
 
-func (f *function) Mutate(m func(*buildv1alpha1.Function)) *function {
-	f = f.deepCopy()
-	m(f.target)
-	return f
+func (b *function) Mutate(m func(*buildv1alpha1.Function)) *function {
+	b = b.deepCopy()
+	m(b.target)
+	return b
 }
 
-func (f *function) NamespaceName(namespace, name string) *function {
-	return f.Mutate(func(fn *buildv1alpha1.Function) {
+func (b *function) NamespaceName(namespace, name string) *function {
+	return b.Mutate(func(fn *buildv1alpha1.Function) {
 		fn.ObjectMeta.Namespace = namespace
 		fn.ObjectMeta.Name = name
 	})
 }
 
-func (f *function) ObjectMeta(nf func(ObjectMeta)) *function {
-	return f.Mutate(func(fn *buildv1alpha1.Function) {
+func (b *function) ObjectMeta(nf func(ObjectMeta)) *function {
+	return b.Mutate(func(fn *buildv1alpha1.Function) {
 		omf := objectMeta(fn.ObjectMeta)
 		nf(omf)
-		fn.ObjectMeta = omf.Get()
+		fn.ObjectMeta = omf.Build()
 	})
 }
 
-func (f *function) Image(format string, a ...interface{}) *function {
-	return f.Mutate(func(fn *buildv1alpha1.Function) {
+func (b *function) Image(format string, a ...interface{}) *function {
+	return b.Mutate(func(fn *buildv1alpha1.Function) {
 		fn.Spec.Image = fmt.Sprintf(format, a...)
 	})
 }
 
-func (f *function) Artifact(artifact string) *function {
-	return f.Mutate(func(fn *buildv1alpha1.Function) {
+func (b *function) Artifact(artifact string) *function {
+	return b.Mutate(func(fn *buildv1alpha1.Function) {
 		fn.Spec.Artifact = artifact
 	})
 }
 
-func (f *function) Handler(handler string) *function {
-	return f.Mutate(func(fn *buildv1alpha1.Function) {
+func (b *function) Handler(handler string) *function {
+	return b.Mutate(func(fn *buildv1alpha1.Function) {
 		fn.Spec.Handler = handler
 	})
 }
 
-func (f *function) Invoker(invoker string) *function {
-	return f.Mutate(func(fn *buildv1alpha1.Function) {
+func (b *function) Invoker(invoker string) *function {
+	return b.Mutate(func(fn *buildv1alpha1.Function) {
 		fn.Spec.Invoker = invoker
 	})
 }
 
-func (f *function) SourceGit(url string, revision string) *function {
-	return f.Mutate(func(fn *buildv1alpha1.Function) {
+func (b *function) SourceGit(url string, revision string) *function {
+	return b.Mutate(func(fn *buildv1alpha1.Function) {
 		if fn.Spec.Source == nil {
 			fn.Spec.Source = &buildv1alpha1.Source{}
 		}
@@ -114,8 +114,8 @@ func (f *function) SourceGit(url string, revision string) *function {
 	})
 }
 
-func (f *function) SourceSubPath(subpath string) *function {
-	return f.Mutate(func(fn *buildv1alpha1.Function) {
+func (b *function) SourceSubPath(subpath string) *function {
+	return b.Mutate(func(fn *buildv1alpha1.Function) {
 		if fn.Spec.Source == nil {
 			fn.Spec.Source = &buildv1alpha1.Source{}
 		}
@@ -123,8 +123,8 @@ func (f *function) SourceSubPath(subpath string) *function {
 	})
 }
 
-func (f *function) BuildCache(quantity string) *function {
-	return f.Mutate(func(fn *buildv1alpha1.Function) {
+func (b *function) BuildCache(quantity string) *function {
+	return b.Mutate(func(fn *buildv1alpha1.Function) {
 		size, err := resource.ParseQuantity(quantity)
 		if err != nil {
 			panic(err)
@@ -133,30 +133,30 @@ func (f *function) BuildCache(quantity string) *function {
 	})
 }
 
-func (f *function) StatusConditions(conditions ...*condition) *function {
-	return f.Mutate(func(fn *buildv1alpha1.Function) {
+func (b *function) StatusConditions(conditions ...*condition) *function {
+	return b.Mutate(func(fn *buildv1alpha1.Function) {
 		c := make([]apis.Condition, len(conditions))
 		for i, cg := range conditions {
-			c[i] = cg.Get()
+			c[i] = cg.Build()
 		}
 		fn.Status.Conditions = c
 	})
 }
 
-func (f *function) StatusReady() *function {
-	return f.StatusConditions(
+func (b *function) StatusReady() *function {
+	return b.StatusConditions(
 		Condition().Type(buildv1alpha1.FunctionConditionReady).True(),
 	)
 }
 
-func (f *function) StatusObservedGeneration(generation int64) *function {
-	return f.Mutate(func(fn *buildv1alpha1.Function) {
+func (b *function) StatusObservedGeneration(generation int64) *function {
+	return b.Mutate(func(fn *buildv1alpha1.Function) {
 		fn.Status.ObservedGeneration = generation
 	})
 }
 
-func (f *function) StatusKpackImageRef(format string, a ...interface{}) *function {
-	return f.Mutate(func(fn *buildv1alpha1.Function) {
+func (b *function) StatusKpackImageRef(format string, a ...interface{}) *function {
+	return b.Mutate(func(fn *buildv1alpha1.Function) {
 		fn.Status.KpackImageRef = &refs.TypedLocalObjectReference{
 			APIGroup: rtesting.StringPtr("build.pivotal.io"),
 			Kind:     "Image",
@@ -165,8 +165,8 @@ func (f *function) StatusKpackImageRef(format string, a ...interface{}) *functio
 	})
 }
 
-func (f *function) StatusBuildCacheRef(format string, a ...interface{}) *function {
-	return f.Mutate(func(fn *buildv1alpha1.Function) {
+func (b *function) StatusBuildCacheRef(format string, a ...interface{}) *function {
+	return b.Mutate(func(fn *buildv1alpha1.Function) {
 		fn.Status.BuildCacheRef = &refs.TypedLocalObjectReference{
 			Kind: "PersistentVolumeClaim",
 			Name: fmt.Sprintf(format, a...),
@@ -174,14 +174,14 @@ func (f *function) StatusBuildCacheRef(format string, a ...interface{}) *functio
 	})
 }
 
-func (f *function) StatusTargetImage(format string, a ...interface{}) *function {
-	return f.Mutate(func(fn *buildv1alpha1.Function) {
+func (b *function) StatusTargetImage(format string, a ...interface{}) *function {
+	return b.Mutate(func(fn *buildv1alpha1.Function) {
 		fn.Status.TargetImage = fmt.Sprintf(format, a...)
 	})
 }
 
-func (f *function) StatusLatestImage(format string, a ...interface{}) *function {
-	return f.Mutate(func(fn *buildv1alpha1.Function) {
+func (b *function) StatusLatestImage(format string, a ...interface{}) *function {
+	return b.Mutate(func(fn *buildv1alpha1.Function) {
 		fn.Status.LatestImage = fmt.Sprintf(format, a...)
 	})
 }

--- a/pkg/controllers/testing/builders/ingress.go
+++ b/pkg/controllers/testing/builders/ingress.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package factories
+package builders
 
 import (
 	"fmt"
@@ -43,37 +43,37 @@ func Ingress(seed ...*networkingv1beta1.Ingress) *ingress {
 	}
 }
 
-func (f *ingress) deepCopy() *ingress {
-	return Ingress(f.target.DeepCopy())
+func (b *ingress) deepCopy() *ingress {
+	return Ingress(b.target.DeepCopy())
 }
 
-func (f *ingress) Get() *networkingv1beta1.Ingress {
-	return f.deepCopy().target
+func (b *ingress) Build() *networkingv1beta1.Ingress {
+	return b.deepCopy().target
 }
 
-func (f *ingress) Mutate(m func(*networkingv1beta1.Ingress)) *ingress {
-	f = f.deepCopy()
-	m(f.target)
-	return f
+func (b *ingress) Mutate(m func(*networkingv1beta1.Ingress)) *ingress {
+	b = b.deepCopy()
+	m(b.target)
+	return b
 }
 
-func (f *ingress) NamespaceName(namespace, name string) *ingress {
-	return f.Mutate(func(sa *networkingv1beta1.Ingress) {
+func (b *ingress) NamespaceName(namespace, name string) *ingress {
+	return b.Mutate(func(sa *networkingv1beta1.Ingress) {
 		sa.ObjectMeta.Namespace = namespace
 		sa.ObjectMeta.Name = name
 	})
 }
 
-func (f *ingress) ObjectMeta(nf func(ObjectMeta)) *ingress {
-	return f.Mutate(func(sa *networkingv1beta1.Ingress) {
+func (b *ingress) ObjectMeta(nf func(ObjectMeta)) *ingress {
+	return b.Mutate(func(sa *networkingv1beta1.Ingress) {
 		omf := objectMeta(sa.ObjectMeta)
 		nf(omf)
-		sa.ObjectMeta = omf.Get()
+		sa.ObjectMeta = omf.Build()
 	})
 }
 
-func (f *ingress) HostToService(host, serviceName string) *ingress {
-	return f.Mutate(func(i *networkingv1beta1.Ingress) {
+func (b *ingress) HostToService(host, serviceName string) *ingress {
+	return b.Mutate(func(i *networkingv1beta1.Ingress) {
 		i.Spec = networkingv1beta1.IngressSpec{
 			Rules: []networkingv1beta1.IngressRule{{
 				Host: host,
@@ -93,8 +93,8 @@ func (f *ingress) HostToService(host, serviceName string) *ingress {
 	})
 }
 
-func (f *ingress) StatusLoadBalancer(ingress ...corev1.LoadBalancerIngress) *ingress {
-	return f.Mutate(func(i *networkingv1beta1.Ingress) {
+func (b *ingress) StatusLoadBalancer(ingress ...corev1.LoadBalancerIngress) *ingress {
+	return b.Mutate(func(i *networkingv1beta1.Ingress) {
 		i.Status.LoadBalancer.Ingress = ingress
 	})
 }

--- a/pkg/controllers/testing/builders/keda_scaledobject.go
+++ b/pkg/controllers/testing/builders/keda_scaledobject.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package factories
+package builders
 
 import (
 	"fmt"
@@ -41,67 +41,67 @@ func KedaScaledObject(seed ...*kedav1alpha1.ScaledObject) *kedaScaledObject {
 	}
 }
 
-func (f *kedaScaledObject) deepCopy() *kedaScaledObject {
-	return KedaScaledObject(f.target.DeepCopy())
+func (b *kedaScaledObject) deepCopy() *kedaScaledObject {
+	return KedaScaledObject(b.target.DeepCopy())
 }
 
-func (f *kedaScaledObject) Get() *kedav1alpha1.ScaledObject {
-	return f.deepCopy().target
+func (b *kedaScaledObject) Build() *kedav1alpha1.ScaledObject {
+	return b.deepCopy().target
 }
 
-func (f *kedaScaledObject) Mutate(m func(*kedav1alpha1.ScaledObject)) *kedaScaledObject {
-	f = f.deepCopy()
-	m(f.target)
-	return f
+func (b *kedaScaledObject) Mutate(m func(*kedav1alpha1.ScaledObject)) *kedaScaledObject {
+	b = b.deepCopy()
+	m(b.target)
+	return b
 }
 
-func (f *kedaScaledObject) NamespaceName(namespace, name string) *kedaScaledObject {
-	return f.Mutate(func(s *kedav1alpha1.ScaledObject) {
+func (b *kedaScaledObject) NamespaceName(namespace, name string) *kedaScaledObject {
+	return b.Mutate(func(s *kedav1alpha1.ScaledObject) {
 		s.ObjectMeta.Namespace = namespace
 		s.ObjectMeta.Name = name
 	})
 }
 
-func (f *kedaScaledObject) ObjectMeta(nf func(ObjectMeta)) *kedaScaledObject {
-	return f.Mutate(func(s *kedav1alpha1.ScaledObject) {
+func (b *kedaScaledObject) ObjectMeta(nf func(ObjectMeta)) *kedaScaledObject {
+	return b.Mutate(func(s *kedav1alpha1.ScaledObject) {
 		omf := objectMeta(s.ObjectMeta)
 		nf(omf)
-		s.ObjectMeta = omf.Get()
+		s.ObjectMeta = omf.Build()
 	})
 }
 
-func (f *kedaScaledObject) Spec(spec *kedav1alpha1.ScaledObjectSpec) *kedaScaledObject {
-	return f.Mutate(func(s *kedav1alpha1.ScaledObject) {
+func (b *kedaScaledObject) Spec(spec *kedav1alpha1.ScaledObjectSpec) *kedaScaledObject {
+	return b.Mutate(func(s *kedav1alpha1.ScaledObject) {
 		s.Spec = *spec
 	})
 }
 
-func (f *kedaScaledObject) ScaleTargetRefDeployment(format string, a ...interface{}) *kedaScaledObject {
-	return f.Mutate(func(s *kedav1alpha1.ScaledObject) {
+func (b *kedaScaledObject) ScaleTargetRefDeployment(format string, a ...interface{}) *kedaScaledObject {
+	return b.Mutate(func(s *kedav1alpha1.ScaledObject) {
 		s.Spec.ScaleTargetRef = &kedav1alpha1.ObjectReference{DeploymentName: fmt.Sprintf(format, a...)}
 	})
 }
 
-func (f *kedaScaledObject) PollingInterval(pollingInterval int32) *kedaScaledObject {
-	return f.Mutate(func(s *kedav1alpha1.ScaledObject) {
+func (b *kedaScaledObject) PollingInterval(pollingInterval int32) *kedaScaledObject {
+	return b.Mutate(func(s *kedav1alpha1.ScaledObject) {
 		s.Spec.PollingInterval = &pollingInterval
 	})
 }
 
-func (f *kedaScaledObject) CooldownPeriod(cooldownPeriod int32) *kedaScaledObject {
-	return f.Mutate(func(s *kedav1alpha1.ScaledObject) {
+func (b *kedaScaledObject) CooldownPeriod(cooldownPeriod int32) *kedaScaledObject {
+	return b.Mutate(func(s *kedav1alpha1.ScaledObject) {
 		s.Spec.CooldownPeriod = &cooldownPeriod
 	})
 }
 
-func (f *kedaScaledObject) MinReplicaCount(minReplicaCount int32) *kedaScaledObject {
-	return f.Mutate(func(s *kedav1alpha1.ScaledObject) {
+func (b *kedaScaledObject) MinReplicaCount(minReplicaCount int32) *kedaScaledObject {
+	return b.Mutate(func(s *kedav1alpha1.ScaledObject) {
 		s.Spec.MinReplicaCount = &minReplicaCount
 	})
 }
 
-func (f *kedaScaledObject) MaxReplicaCount(maxReplicaCount int32) *kedaScaledObject {
-	return f.Mutate(func(s *kedav1alpha1.ScaledObject) {
+func (b *kedaScaledObject) MaxReplicaCount(maxReplicaCount int32) *kedaScaledObject {
+	return b.Mutate(func(s *kedav1alpha1.ScaledObject) {
 		s.Spec.MaxReplicaCount = &maxReplicaCount
 	})
 }

--- a/pkg/controllers/testing/builders/knative_route.go
+++ b/pkg/controllers/testing/builders/knative_route.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package factories
+package builders
 
 import (
 	"fmt"
@@ -42,73 +42,73 @@ func KnativeRoute(seed ...*knativeservingv1.Route) *knativeRoute {
 	}
 }
 
-func (f *knativeRoute) deepCopy() *knativeRoute {
-	return KnativeRoute(f.target.DeepCopy())
+func (b *knativeRoute) deepCopy() *knativeRoute {
+	return KnativeRoute(b.target.DeepCopy())
 }
 
-func (f *knativeRoute) Get() *knativeservingv1.Route {
-	return f.deepCopy().target
+func (b *knativeRoute) Build() *knativeservingv1.Route {
+	return b.deepCopy().target
 }
 
-func (f *knativeRoute) Mutate(m func(*knativeservingv1.Route)) *knativeRoute {
-	f = f.deepCopy()
-	m(f.target)
-	return f
+func (b *knativeRoute) Mutate(m func(*knativeservingv1.Route)) *knativeRoute {
+	b = b.deepCopy()
+	m(b.target)
+	return b
 }
 
-func (f *knativeRoute) NamespaceName(namespace, name string) *knativeRoute {
-	return f.Mutate(func(route *knativeservingv1.Route) {
+func (b *knativeRoute) NamespaceName(namespace, name string) *knativeRoute {
+	return b.Mutate(func(route *knativeservingv1.Route) {
 		route.ObjectMeta.Namespace = namespace
 		route.ObjectMeta.Name = name
 	})
 }
 
-func (f *knativeRoute) ObjectMeta(nf func(ObjectMeta)) *knativeRoute {
-	return f.Mutate(func(route *knativeservingv1.Route) {
+func (b *knativeRoute) ObjectMeta(nf func(ObjectMeta)) *knativeRoute {
+	return b.Mutate(func(route *knativeservingv1.Route) {
 		omf := objectMeta(route.ObjectMeta)
 		nf(omf)
-		route.ObjectMeta = omf.Get()
+		route.ObjectMeta = omf.Build()
 	})
 }
 
-func (f *knativeRoute) Traffic(traffic ...knativeservingv1.TrafficTarget) *knativeRoute {
-	return f.Mutate(func(route *knativeservingv1.Route) {
+func (b *knativeRoute) Traffic(traffic ...knativeservingv1.TrafficTarget) *knativeRoute {
+	return b.Mutate(func(route *knativeservingv1.Route) {
 		route.Spec.Traffic = traffic
 	})
 }
 
-func (f *knativeRoute) StatusConditions(conditions ...*condition) *knativeRoute {
-	return f.Mutate(func(route *knativeservingv1.Route) {
+func (b *knativeRoute) StatusConditions(conditions ...*condition) *knativeRoute {
+	return b.Mutate(func(route *knativeservingv1.Route) {
 		c := make([]apis.Condition, len(conditions))
 		for i, cg := range conditions {
-			c[i] = cg.Get()
+			c[i] = cg.Build()
 		}
 		route.Status.Conditions = c
 	})
 }
 
-func (f *knativeRoute) StatusReady() *knativeRoute {
-	return f.StatusConditions(
+func (b *knativeRoute) StatusReady() *knativeRoute {
+	return b.StatusConditions(
 		Condition().Type(knativeservingv1.RouteConditionReady).True(),
 	)
 }
 
-func (f *knativeRoute) StatusObservedGeneration(generation int64) *knativeRoute {
-	return f.Mutate(func(route *knativeservingv1.Route) {
+func (b *knativeRoute) StatusObservedGeneration(generation int64) *knativeRoute {
+	return b.Mutate(func(route *knativeservingv1.Route) {
 		route.Status.ObservedGeneration = generation
 	})
 }
 
-func (f *knativeRoute) StatusAddressURL(url string) *knativeRoute {
-	return f.Mutate(func(route *knativeservingv1.Route) {
+func (b *knativeRoute) StatusAddressURL(url string) *knativeRoute {
+	return b.Mutate(func(route *knativeservingv1.Route) {
 		route.Status.Address = &apis.Addressable{
 			URL: url,
 		}
 	})
 }
 
-func (f *knativeRoute) StatusURL(url string) *knativeRoute {
-	return f.Mutate(func(route *knativeservingv1.Route) {
+func (b *knativeRoute) StatusURL(url string) *knativeRoute {
+	return b.Mutate(func(route *knativeservingv1.Route) {
 		route.Status.URL = url
 	})
 }

--- a/pkg/controllers/testing/builders/kpack_clusterbuilder.go
+++ b/pkg/controllers/testing/builders/kpack_clusterbuilder.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package factories
+package builders
 
 import (
 	"fmt"
@@ -42,65 +42,65 @@ func KpackClusterBuilder(seed ...*kpackbuildv1alpha1.ClusterBuilder) *kpackClust
 	}
 }
 
-func (f *kpackClusterBuilder) deepCopy() *kpackClusterBuilder {
-	return KpackClusterBuilder(f.target.DeepCopy())
+func (b *kpackClusterBuilder) deepCopy() *kpackClusterBuilder {
+	return KpackClusterBuilder(b.target.DeepCopy())
 }
 
-func (f *kpackClusterBuilder) Get() *kpackbuildv1alpha1.ClusterBuilder {
-	return f.deepCopy().target
+func (b *kpackClusterBuilder) Build() *kpackbuildv1alpha1.ClusterBuilder {
+	return b.deepCopy().target
 }
 
-func (f *kpackClusterBuilder) Mutate(m func(*kpackbuildv1alpha1.ClusterBuilder)) *kpackClusterBuilder {
-	f = f.deepCopy()
-	m(f.target)
-	return f
+func (b *kpackClusterBuilder) Mutate(m func(*kpackbuildv1alpha1.ClusterBuilder)) *kpackClusterBuilder {
+	b = b.deepCopy()
+	m(b.target)
+	return b
 }
 
-func (f *kpackClusterBuilder) NamespaceName(namespace, name string) *kpackClusterBuilder {
-	return f.Mutate(func(cb *kpackbuildv1alpha1.ClusterBuilder) {
+func (b *kpackClusterBuilder) NamespaceName(namespace, name string) *kpackClusterBuilder {
+	return b.Mutate(func(cb *kpackbuildv1alpha1.ClusterBuilder) {
 		cb.ObjectMeta.Namespace = namespace
 		cb.ObjectMeta.Name = name
 	})
 }
 
-func (f *kpackClusterBuilder) ObjectMeta(nf func(ObjectMeta)) *kpackClusterBuilder {
-	return f.Mutate(func(cb *kpackbuildv1alpha1.ClusterBuilder) {
+func (b *kpackClusterBuilder) ObjectMeta(nf func(ObjectMeta)) *kpackClusterBuilder {
+	return b.Mutate(func(cb *kpackbuildv1alpha1.ClusterBuilder) {
 		omf := objectMeta(cb.ObjectMeta)
 		nf(omf)
-		cb.ObjectMeta = omf.Get()
+		cb.ObjectMeta = omf.Build()
 	})
 }
 
-func (f *kpackClusterBuilder) Image(format string, a ...interface{}) *kpackClusterBuilder {
-	return f.Mutate(func(cb *kpackbuildv1alpha1.ClusterBuilder) {
+func (b *kpackClusterBuilder) Image(format string, a ...interface{}) *kpackClusterBuilder {
+	return b.Mutate(func(cb *kpackbuildv1alpha1.ClusterBuilder) {
 		cb.Spec.Image = fmt.Sprintf(format, a...)
 	})
 }
 
-func (f *kpackClusterBuilder) StatusConditions(conditions ...*condition) *kpackClusterBuilder {
-	return f.Mutate(func(cb *kpackbuildv1alpha1.ClusterBuilder) {
+func (b *kpackClusterBuilder) StatusConditions(conditions ...*condition) *kpackClusterBuilder {
+	return b.Mutate(func(cb *kpackbuildv1alpha1.ClusterBuilder) {
 		c := make([]apis.Condition, len(conditions))
 		for i, cg := range conditions {
-			c[i] = cg.Get()
+			c[i] = cg.Build()
 		}
 		cb.Status.Conditions = c
 	})
 }
 
-func (f *kpackClusterBuilder) StatusReady() *kpackClusterBuilder {
-	return f.StatusConditions(
+func (b *kpackClusterBuilder) StatusReady() *kpackClusterBuilder {
+	return b.StatusConditions(
 		Condition().Type(apis.ConditionReady).True(),
 	)
 }
 
-func (f *kpackClusterBuilder) StatusObservedGeneration(generation int64) *kpackClusterBuilder {
-	return f.Mutate(func(cb *kpackbuildv1alpha1.ClusterBuilder) {
+func (b *kpackClusterBuilder) StatusObservedGeneration(generation int64) *kpackClusterBuilder {
+	return b.Mutate(func(cb *kpackbuildv1alpha1.ClusterBuilder) {
 		cb.Status.ObservedGeneration = generation
 	})
 }
 
-func (f *kpackClusterBuilder) StatusLatestImage(format string, a ...interface{}) *kpackClusterBuilder {
-	return f.Mutate(func(cb *kpackbuildv1alpha1.ClusterBuilder) {
+func (b *kpackClusterBuilder) StatusLatestImage(format string, a ...interface{}) *kpackClusterBuilder {
+	return b.Mutate(func(cb *kpackbuildv1alpha1.ClusterBuilder) {
 		cb.Status.LatestImage = fmt.Sprintf(format, a...)
 	})
 }

--- a/pkg/controllers/testing/builders/kpack_image.go
+++ b/pkg/controllers/testing/builders/kpack_image.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package factories
+package builders
 
 import (
 	"fmt"
@@ -46,37 +46,37 @@ func KpackImage(seed ...*kpackbuildv1alpha1.Image) *kpackImage {
 	}
 }
 
-func (f *kpackImage) deepCopy() *kpackImage {
-	return KpackImage(f.target.DeepCopy())
+func (b *kpackImage) deepCopy() *kpackImage {
+	return KpackImage(b.target.DeepCopy())
 }
 
-func (f *kpackImage) Get() *kpackbuildv1alpha1.Image {
-	return f.deepCopy().target
+func (b *kpackImage) Build() *kpackbuildv1alpha1.Image {
+	return b.deepCopy().target
 }
 
-func (f *kpackImage) Mutate(m func(*kpackbuildv1alpha1.Image)) *kpackImage {
-	f = f.deepCopy()
-	m(f.target)
-	return f
+func (b *kpackImage) Mutate(m func(*kpackbuildv1alpha1.Image)) *kpackImage {
+	b = b.deepCopy()
+	m(b.target)
+	return b
 }
 
-func (f *kpackImage) NamespaceName(namespace, name string) *kpackImage {
-	return f.Mutate(func(image *kpackbuildv1alpha1.Image) {
+func (b *kpackImage) NamespaceName(namespace, name string) *kpackImage {
+	return b.Mutate(func(image *kpackbuildv1alpha1.Image) {
 		image.ObjectMeta.Namespace = namespace
 		image.ObjectMeta.Name = name
 	})
 }
 
-func (f *kpackImage) ObjectMeta(nf func(ObjectMeta)) *kpackImage {
-	return f.Mutate(func(image *kpackbuildv1alpha1.Image) {
+func (b *kpackImage) ObjectMeta(nf func(ObjectMeta)) *kpackImage {
+	return b.Mutate(func(image *kpackbuildv1alpha1.Image) {
 		omf := objectMeta(image.ObjectMeta)
 		nf(omf)
-		image.ObjectMeta = omf.Get()
+		image.ObjectMeta = omf.Build()
 	})
 }
 
-func (f *kpackImage) ApplicationBuilder() *kpackImage {
-	return f.Mutate(func(image *kpackbuildv1alpha1.Image) {
+func (b *kpackImage) ApplicationBuilder() *kpackImage {
+	return b.Mutate(func(image *kpackbuildv1alpha1.Image) {
 		image.Spec.Builder = kpackbuildv1alpha1.ImageBuilder{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "ClusterBuilder",
@@ -87,8 +87,8 @@ func (f *kpackImage) ApplicationBuilder() *kpackImage {
 	})
 }
 
-func (f *kpackImage) FunctionBuilder(artifact, handler, invoker string) *kpackImage {
-	return f.Mutate(func(image *kpackbuildv1alpha1.Image) {
+func (b *kpackImage) FunctionBuilder(artifact, handler, invoker string) *kpackImage {
+	return b.Mutate(func(image *kpackbuildv1alpha1.Image) {
 		image.Spec.Builder = kpackbuildv1alpha1.ImageBuilder{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "ClusterBuilder",
@@ -125,14 +125,14 @@ func (f *kpackImage) FunctionBuilder(artifact, handler, invoker string) *kpackIm
 	})
 }
 
-func (f *kpackImage) Tag(format string, a ...interface{}) *kpackImage {
-	return f.Mutate(func(image *kpackbuildv1alpha1.Image) {
+func (b *kpackImage) Tag(format string, a ...interface{}) *kpackImage {
+	return b.Mutate(func(image *kpackbuildv1alpha1.Image) {
 		image.Spec.Tag = fmt.Sprintf(format, a...)
 	})
 }
 
-func (f *kpackImage) SourceGit(url string, revision string) *kpackImage {
-	return f.Mutate(func(image *kpackbuildv1alpha1.Image) {
+func (b *kpackImage) SourceGit(url string, revision string) *kpackImage {
+	return b.Mutate(func(image *kpackbuildv1alpha1.Image) {
 		image.Spec.Source = kpackbuildv1alpha1.SourceConfig{
 			Git: &kpackbuildv1alpha1.Git{
 				URL:      url,
@@ -143,14 +143,14 @@ func (f *kpackImage) SourceGit(url string, revision string) *kpackImage {
 	})
 }
 
-func (f *kpackImage) SourceSubPath(subpath string) *kpackImage {
-	return f.Mutate(func(image *kpackbuildv1alpha1.Image) {
+func (b *kpackImage) SourceSubPath(subpath string) *kpackImage {
+	return b.Mutate(func(image *kpackbuildv1alpha1.Image) {
 		image.Spec.Source.SubPath = subpath
 	})
 }
 
-func (f *kpackImage) BuildCache(quantity string) *kpackImage {
-	return f.Mutate(func(image *kpackbuildv1alpha1.Image) {
+func (b *kpackImage) BuildCache(quantity string) *kpackImage {
+	return b.Mutate(func(image *kpackbuildv1alpha1.Image) {
 		size, err := resource.ParseQuantity(quantity)
 		if err != nil {
 			panic(err)
@@ -159,36 +159,36 @@ func (f *kpackImage) BuildCache(quantity string) *kpackImage {
 	})
 }
 
-func (f *kpackImage) StatusConditions(conditions ...*condition) *kpackImage {
-	return f.Mutate(func(image *kpackbuildv1alpha1.Image) {
+func (b *kpackImage) StatusConditions(conditions ...*condition) *kpackImage {
+	return b.Mutate(func(image *kpackbuildv1alpha1.Image) {
 		c := make([]apis.Condition, len(conditions))
 		for i, cg := range conditions {
-			c[i] = cg.Get()
+			c[i] = cg.Build()
 		}
 		image.Status.Conditions = c
 	})
 }
 
-func (f *kpackImage) StatusReady() *kpackImage {
-	return f.StatusConditions(
+func (b *kpackImage) StatusReady() *kpackImage {
+	return b.StatusConditions(
 		Condition().Type(apis.ConditionReady).True(),
 	)
 }
 
-func (f *kpackImage) StatusObservedGeneration(generation int64) *kpackImage {
-	return f.Mutate(func(image *kpackbuildv1alpha1.Image) {
+func (b *kpackImage) StatusObservedGeneration(generation int64) *kpackImage {
+	return b.Mutate(func(image *kpackbuildv1alpha1.Image) {
 		image.Status.ObservedGeneration = generation
 	})
 }
 
-func (f *kpackImage) StatusLatestImage(format string, a ...interface{}) *kpackImage {
-	return f.Mutate(func(image *kpackbuildv1alpha1.Image) {
+func (b *kpackImage) StatusLatestImage(format string, a ...interface{}) *kpackImage {
+	return b.Mutate(func(image *kpackbuildv1alpha1.Image) {
 		image.Status.LatestImage = fmt.Sprintf(format, a...)
 	})
 }
 
-func (f *kpackImage) StatusBuildCacheName(format string, a ...interface{}) *kpackImage {
-	return f.Mutate(func(image *kpackbuildv1alpha1.Image) {
+func (b *kpackImage) StatusBuildCacheName(format string, a ...interface{}) *kpackImage {
+	return b.Mutate(func(image *kpackbuildv1alpha1.Image) {
 		image.Status.BuildCacheName = fmt.Sprintf(format, a...)
 	})
 }

--- a/pkg/controllers/testing/builders/objectmeta.go
+++ b/pkg/controllers/testing/builders/objectmeta.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package factories
+package builders
 
 import (
 	"fmt"
@@ -26,7 +26,7 @@ import (
 
 type ObjectMeta interface {
 	Mutate(m func(*metav1.ObjectMeta)) ObjectMeta
-	Get() metav1.ObjectMeta
+	Build() metav1.ObjectMeta
 
 	Namespace(namespace string) ObjectMeta
 	Name(format string, a ...interface{}) ObjectMeta
@@ -49,35 +49,35 @@ func objectMeta(seed metav1.ObjectMeta) *objectMetaImpl {
 	}
 }
 
-func (f *objectMetaImpl) Get() metav1.ObjectMeta {
-	return *(f.target.DeepCopy())
+func (b *objectMetaImpl) Build() metav1.ObjectMeta {
+	return *(b.target.DeepCopy())
 }
 
-func (f *objectMetaImpl) Mutate(m func(*metav1.ObjectMeta)) ObjectMeta {
-	m(f.target)
-	return f
+func (b *objectMetaImpl) Mutate(m func(*metav1.ObjectMeta)) ObjectMeta {
+	m(b.target)
+	return b
 }
 
-func (f *objectMetaImpl) Namespace(namespace string) ObjectMeta {
-	return f.Mutate(func(om *metav1.ObjectMeta) {
+func (b *objectMetaImpl) Namespace(namespace string) ObjectMeta {
+	return b.Mutate(func(om *metav1.ObjectMeta) {
 		om.Namespace = namespace
 	})
 }
 
-func (f *objectMetaImpl) Name(format string, a ...interface{}) ObjectMeta {
-	return f.Mutate(func(om *metav1.ObjectMeta) {
+func (b *objectMetaImpl) Name(format string, a ...interface{}) ObjectMeta {
+	return b.Mutate(func(om *metav1.ObjectMeta) {
 		om.Name = fmt.Sprintf(format, a...)
 	})
 }
 
-func (f *objectMetaImpl) GenerateName(format string, a ...interface{}) ObjectMeta {
-	return f.Mutate(func(om *metav1.ObjectMeta) {
+func (b *objectMetaImpl) GenerateName(format string, a ...interface{}) ObjectMeta {
+	return b.Mutate(func(om *metav1.ObjectMeta) {
 		om.GenerateName = fmt.Sprintf(format, a...)
 	})
 }
 
-func (f *objectMetaImpl) AddLabel(key, value string) ObjectMeta {
-	return f.Mutate(func(om *metav1.ObjectMeta) {
+func (b *objectMetaImpl) AddLabel(key, value string) ObjectMeta {
+	return b.Mutate(func(om *metav1.ObjectMeta) {
 		if om.Labels == nil {
 			om.Labels = map[string]string{}
 		}
@@ -85,8 +85,8 @@ func (f *objectMetaImpl) AddLabel(key, value string) ObjectMeta {
 	})
 }
 
-func (f *objectMetaImpl) AddAnnotation(key, value string) ObjectMeta {
-	return f.Mutate(func(om *metav1.ObjectMeta) {
+func (b *objectMetaImpl) AddAnnotation(key, value string) ObjectMeta {
+	return b.Mutate(func(om *metav1.ObjectMeta) {
 		if om.Annotations == nil {
 			om.Annotations = map[string]string{}
 		}
@@ -94,14 +94,14 @@ func (f *objectMetaImpl) AddAnnotation(key, value string) ObjectMeta {
 	})
 }
 
-func (f *objectMetaImpl) Generation(generation int64) ObjectMeta {
-	return f.Mutate(func(om *metav1.ObjectMeta) {
+func (b *objectMetaImpl) Generation(generation int64) ObjectMeta {
+	return b.Mutate(func(om *metav1.ObjectMeta) {
 		om.Generation = generation
 	})
 }
 
-func (f *objectMetaImpl) ControlledBy(owner metav1.Object, scheme *runtime.Scheme) ObjectMeta {
-	return f.Mutate(func(om *metav1.ObjectMeta) {
+func (b *objectMetaImpl) ControlledBy(owner metav1.Object, scheme *runtime.Scheme) ObjectMeta {
+	return b.Mutate(func(om *metav1.ObjectMeta) {
 		err := ctrl.SetControllerReference(owner, om, scheme)
 		if err != nil {
 			panic(err)
@@ -109,15 +109,15 @@ func (f *objectMetaImpl) ControlledBy(owner metav1.Object, scheme *runtime.Schem
 	})
 }
 
-func (f *objectMetaImpl) Created(sec int64) ObjectMeta {
-	return f.Mutate(func(om *metav1.ObjectMeta) {
+func (b *objectMetaImpl) Created(sec int64) ObjectMeta {
+	return b.Mutate(func(om *metav1.ObjectMeta) {
 		timestamp := metav1.Unix(sec, 0)
 		om.CreationTimestamp = timestamp
 	})
 }
 
-func (f *objectMetaImpl) Deleted(sec int64) ObjectMeta {
-	return f.Mutate(func(om *metav1.ObjectMeta) {
+func (b *objectMetaImpl) Deleted(sec int64) ObjectMeta {
+	return b.Mutate(func(om *metav1.ObjectMeta) {
 		timestamp := metav1.Unix(sec, 0)
 		om.DeletionTimestamp = &timestamp
 	})

--- a/pkg/controllers/testing/builders/podtemplatespec.go
+++ b/pkg/controllers/testing/builders/podtemplatespec.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package factories
+package builders
 
 import (
 	corev1 "k8s.io/api/core/v1"
@@ -22,7 +22,7 @@ import (
 
 type PodTemplateSpec interface {
 	Mutate(m func(*corev1.PodTemplateSpec)) PodTemplateSpec
-	Get() corev1.PodTemplateSpec
+	Build() corev1.PodTemplateSpec
 
 	AddLabel(key, value string) PodTemplateSpec
 	AddAnnotation(key, value string) PodTemplateSpec
@@ -39,17 +39,17 @@ func podTemplateSpec(seed corev1.PodTemplateSpec) *podTemplateSpecImpl {
 	}
 }
 
-func (f *podTemplateSpecImpl) Get() corev1.PodTemplateSpec {
-	return *(f.target.DeepCopy())
+func (b *podTemplateSpecImpl) Build() corev1.PodTemplateSpec {
+	return *(b.target.DeepCopy())
 }
 
-func (f *podTemplateSpecImpl) Mutate(m func(*corev1.PodTemplateSpec)) PodTemplateSpec {
-	m(f.target)
-	return f
+func (b *podTemplateSpecImpl) Mutate(m func(*corev1.PodTemplateSpec)) PodTemplateSpec {
+	m(b.target)
+	return b
 }
 
-func (f *podTemplateSpecImpl) AddLabel(key, value string) PodTemplateSpec {
-	return f.Mutate(func(pts *corev1.PodTemplateSpec) {
+func (b *podTemplateSpecImpl) AddLabel(key, value string) PodTemplateSpec {
+	return b.Mutate(func(pts *corev1.PodTemplateSpec) {
 		if pts.Labels == nil {
 			pts.Labels = map[string]string{}
 		}
@@ -57,8 +57,8 @@ func (f *podTemplateSpecImpl) AddLabel(key, value string) PodTemplateSpec {
 	})
 }
 
-func (f *podTemplateSpecImpl) AddAnnotation(key, value string) PodTemplateSpec {
-	return f.Mutate(func(pts *corev1.PodTemplateSpec) {
+func (b *podTemplateSpecImpl) AddAnnotation(key, value string) PodTemplateSpec {
+	return b.Mutate(func(pts *corev1.PodTemplateSpec) {
 		if pts.Annotations == nil {
 			pts.Annotations = map[string]string{}
 		}
@@ -66,8 +66,8 @@ func (f *podTemplateSpecImpl) AddAnnotation(key, value string) PodTemplateSpec {
 	})
 }
 
-func (f *podTemplateSpecImpl) ContainerNamed(name string, cb func(*corev1.Container)) PodTemplateSpec {
-	return f.Mutate(func(pts *corev1.PodTemplateSpec) {
+func (b *podTemplateSpecImpl) ContainerNamed(name string, cb func(*corev1.Container)) PodTemplateSpec {
+	return b.Mutate(func(pts *corev1.PodTemplateSpec) {
 		found := false
 		// check for existing container
 		for i, container := range pts.Spec.Containers {

--- a/pkg/controllers/testing/builders/processor.go
+++ b/pkg/controllers/testing/builders/processor.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package factories
+package builders
 
 import (
 	"fmt"
@@ -46,37 +46,37 @@ func Processor(seed ...*streamingv1alpha1.Processor) *processor {
 	}
 }
 
-func (f *processor) deepCopy() *processor {
-	return Processor(f.target.DeepCopy())
+func (b *processor) deepCopy() *processor {
+	return Processor(b.target.DeepCopy())
 }
 
-func (f *processor) Get() *streamingv1alpha1.Processor {
-	return f.deepCopy().target
+func (b *processor) Build() *streamingv1alpha1.Processor {
+	return b.deepCopy().target
 }
 
-func (f *processor) Mutate(m func(*streamingv1alpha1.Processor)) *processor {
-	f = f.deepCopy()
-	m(f.target)
-	return f
+func (b *processor) Mutate(m func(*streamingv1alpha1.Processor)) *processor {
+	b = b.deepCopy()
+	m(b.target)
+	return b
 }
 
-func (f *processor) NamespaceName(namespace, name string) *processor {
-	return f.Mutate(func(p *streamingv1alpha1.Processor) {
+func (b *processor) NamespaceName(namespace, name string) *processor {
+	return b.Mutate(func(p *streamingv1alpha1.Processor) {
 		p.ObjectMeta.Namespace = namespace
 		p.ObjectMeta.Name = name
 	})
 }
 
-func (f *processor) ObjectMeta(nf func(ObjectMeta)) *processor {
-	return f.Mutate(func(s *streamingv1alpha1.Processor) {
+func (b *processor) ObjectMeta(nf func(ObjectMeta)) *processor {
+	return b.Mutate(func(s *streamingv1alpha1.Processor) {
 		omf := objectMeta(s.ObjectMeta)
 		nf(omf)
-		s.ObjectMeta = omf.Get()
+		s.ObjectMeta = omf.Build()
 	})
 }
 
-func (f *processor) PodTemplateSpec(nf func(PodTemplateSpec)) *processor {
-	return f.Mutate(func(processor *streamingv1alpha1.Processor) {
+func (b *processor) PodTemplateSpec(nf func(PodTemplateSpec)) *processor {
+	return b.Mutate(func(processor *streamingv1alpha1.Processor) {
 		var ptsf *podTemplateSpecImpl
 		if processor.Spec.Template != nil {
 			ptsf = podTemplateSpec(*processor.Spec.Template)
@@ -84,16 +84,16 @@ func (f *processor) PodTemplateSpec(nf func(PodTemplateSpec)) *processor {
 			ptsf = podTemplateSpec(corev1.PodTemplateSpec{})
 		}
 		nf(ptsf)
-		templateSpec := ptsf.Get()
+		templateSpec := ptsf.Build()
 		processor.Spec.Template = &templateSpec
 	})
 }
 
-func (f *processor) StatusConditions(conditions ...*condition) *processor {
-	return f.Mutate(func(processor *streamingv1alpha1.Processor) {
+func (b *processor) StatusConditions(conditions ...*condition) *processor {
+	return b.Mutate(func(processor *streamingv1alpha1.Processor) {
 		c := make([]apis.Condition, len(conditions))
 		for i, cg := range conditions {
-			dc := cg.Get()
+			dc := cg.Build()
 			c[i] = apis.Condition{
 				Type:    apis.ConditionType(dc.Type),
 				Status:  dc.Status,
@@ -105,14 +105,14 @@ func (f *processor) StatusConditions(conditions ...*condition) *processor {
 	})
 }
 
-func (f *processor) StatusLatestImage(image string) *processor {
-	return f.Mutate(func(proc *streamingv1alpha1.Processor) {
+func (b *processor) StatusLatestImage(image string) *processor {
+	return b.Mutate(func(proc *streamingv1alpha1.Processor) {
 		proc.Status.LatestImage = image
 	})
 }
 
-func (f *processor) StatusDeploymentRef(deploymentName string) *processor {
-	return f.Mutate(func(proc *streamingv1alpha1.Processor) {
+func (b *processor) StatusDeploymentRef(deploymentName string) *processor {
+	return b.Mutate(func(proc *streamingv1alpha1.Processor) {
 		proc.Status.DeploymentRef = &refs.TypedLocalObjectReference{
 			APIGroup: rtesting.StringPtr("apps"),
 			Kind:     "Deployment",
@@ -121,24 +121,24 @@ func (f *processor) StatusDeploymentRef(deploymentName string) *processor {
 	})
 }
 
-func (f *processor) SpecBuildFunctionRef(functionName string) *processor {
-	return f.Mutate(func(proc *streamingv1alpha1.Processor) {
+func (b *processor) SpecBuildFunctionRef(functionName string) *processor {
+	return b.Mutate(func(proc *streamingv1alpha1.Processor) {
 		proc.Spec.Build = &streamingv1alpha1.Build{
 			FunctionRef: functionName,
 		}
 	})
 }
 
-func (f *processor) SpecBuildContainerRef(containerName string) *processor {
-	return f.Mutate(func(proc *streamingv1alpha1.Processor) {
+func (b *processor) SpecBuildContainerRef(containerName string) *processor {
+	return b.Mutate(func(proc *streamingv1alpha1.Processor) {
 		proc.Spec.Build = &streamingv1alpha1.Build{
 			ContainerRef: containerName,
 		}
 	})
 }
 
-func (f *processor) StatusScaledObjectRef(deploymentName string) *processor {
-	return f.Mutate(func(proc *streamingv1alpha1.Processor) {
+func (b *processor) StatusScaledObjectRef(deploymentName string) *processor {
+	return b.Mutate(func(proc *streamingv1alpha1.Processor) {
 		proc.Status.ScaledObjectRef = &refs.TypedLocalObjectReference{
 			APIGroup: rtesting.StringPtr("keda.k8s.io"),
 			Kind:     "ScaledObject",

--- a/pkg/controllers/testing/builders/secret.go
+++ b/pkg/controllers/testing/builders/secret.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package factories
+package builders
 
 import (
 	"encoding/base64"
@@ -42,43 +42,43 @@ func Secret(seed ...*corev1.Secret) *secret {
 	}
 }
 
-func (f *secret) deepCopy() *secret {
-	return Secret(f.target.DeepCopy())
+func (b *secret) deepCopy() *secret {
+	return Secret(b.target.DeepCopy())
 }
 
-func (f *secret) Get() *corev1.Secret {
-	return f.deepCopy().target
+func (b *secret) Build() *corev1.Secret {
+	return b.deepCopy().target
 }
 
-func (f *secret) Mutate(m func(*corev1.Secret)) *secret {
-	f = f.deepCopy()
-	m(f.target)
-	return f
+func (b *secret) Mutate(m func(*corev1.Secret)) *secret {
+	b = b.deepCopy()
+	m(b.target)
+	return b
 }
 
-func (f *secret) NamespaceName(namespace, name string) *secret {
-	return f.Mutate(func(s *corev1.Secret) {
+func (b *secret) NamespaceName(namespace, name string) *secret {
+	return b.Mutate(func(s *corev1.Secret) {
 		s.ObjectMeta.Namespace = namespace
 		s.ObjectMeta.Name = name
 	})
 }
 
-func (f *secret) ObjectMeta(nf func(ObjectMeta)) *secret {
-	return f.Mutate(func(s *corev1.Secret) {
+func (b *secret) ObjectMeta(nf func(ObjectMeta)) *secret {
+	return b.Mutate(func(s *corev1.Secret) {
 		omf := objectMeta(s.ObjectMeta)
 		nf(omf)
-		s.ObjectMeta = omf.Get()
+		s.ObjectMeta = omf.Build()
 	})
 }
 
-func (f *secret) Type(t corev1.SecretType) *secret {
-	return f.Mutate(func(s *corev1.Secret) {
+func (b *secret) Type(t corev1.SecretType) *secret {
+	return b.Mutate(func(s *corev1.Secret) {
 		s.Type = t
 	})
 }
 
-func (f *secret) AddData(key, value string) *secret {
-	return f.Mutate(func(s *corev1.Secret) {
+func (b *secret) AddData(key, value string) *secret {
+	return b.Mutate(func(s *corev1.Secret) {
 		if s.Data == nil {
 			s.Data = map[string][]byte{}
 		}

--- a/pkg/controllers/testing/builders/service.go
+++ b/pkg/controllers/testing/builders/service.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package factories
+package builders
 
 import (
 	"fmt"
@@ -41,37 +41,37 @@ func Service(seed ...*corev1.Service) *service {
 	}
 }
 
-func (f *service) deepCopy() *service {
-	return Service(f.target.DeepCopy())
+func (b *service) deepCopy() *service {
+	return Service(b.target.DeepCopy())
 }
 
-func (f *service) Get() *corev1.Service {
-	return f.deepCopy().target
+func (b *service) Build() *corev1.Service {
+	return b.deepCopy().target
 }
 
-func (f *service) Mutate(m func(*corev1.Service)) *service {
-	f = f.deepCopy()
-	m(f.target)
-	return f
+func (b *service) Mutate(m func(*corev1.Service)) *service {
+	b = b.deepCopy()
+	m(b.target)
+	return b
 }
 
-func (f *service) NamespaceName(namespace, name string) *service {
-	return f.Mutate(func(sa *corev1.Service) {
+func (b *service) NamespaceName(namespace, name string) *service {
+	return b.Mutate(func(sa *corev1.Service) {
 		sa.ObjectMeta.Namespace = namespace
 		sa.ObjectMeta.Name = name
 	})
 }
 
-func (f *service) ObjectMeta(nf func(ObjectMeta)) *service {
-	return f.Mutate(func(sa *corev1.Service) {
+func (b *service) ObjectMeta(nf func(ObjectMeta)) *service {
+	return b.Mutate(func(sa *corev1.Service) {
 		omf := objectMeta(sa.ObjectMeta)
 		nf(omf)
-		sa.ObjectMeta = omf.Get()
+		sa.ObjectMeta = omf.Build()
 	})
 }
 
-func (f *service) AddSelectorLabel(key, value string) *service {
-	return f.Mutate(func(service *corev1.Service) {
+func (b *service) AddSelectorLabel(key, value string) *service {
+	return b.Mutate(func(service *corev1.Service) {
 		if service.Spec.Selector == nil {
 			service.Spec.Selector = map[string]string{}
 		}
@@ -79,8 +79,8 @@ func (f *service) AddSelectorLabel(key, value string) *service {
 	})
 }
 
-func (f *service) Ports(ports ...corev1.ServicePort) *service {
-	return f.Mutate(func(service *corev1.Service) {
+func (b *service) Ports(ports ...corev1.ServicePort) *service {
+	return b.Mutate(func(service *corev1.Service) {
 		service.Spec.Ports = ports
 	})
 }

--- a/pkg/controllers/testing/builders/serviceaccount.go
+++ b/pkg/controllers/testing/builders/serviceaccount.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package factories
+package builders
 
 import (
 	"fmt"
@@ -41,37 +41,37 @@ func ServiceAccount(seed ...*corev1.ServiceAccount) *serviceAccount {
 	}
 }
 
-func (f *serviceAccount) deepCopy() *serviceAccount {
-	return ServiceAccount(f.target.DeepCopy())
+func (b *serviceAccount) deepCopy() *serviceAccount {
+	return ServiceAccount(b.target.DeepCopy())
 }
 
-func (f *serviceAccount) Get() *corev1.ServiceAccount {
-	return f.deepCopy().target
+func (b *serviceAccount) Build() *corev1.ServiceAccount {
+	return b.deepCopy().target
 }
 
-func (f *serviceAccount) Mutate(m func(*corev1.ServiceAccount)) *serviceAccount {
-	f = f.deepCopy()
-	m(f.target)
-	return f
+func (b *serviceAccount) Mutate(m func(*corev1.ServiceAccount)) *serviceAccount {
+	b = b.deepCopy()
+	m(b.target)
+	return b
 }
 
-func (f *serviceAccount) NamespaceName(namespace, name string) *serviceAccount {
-	return f.Mutate(func(sa *corev1.ServiceAccount) {
+func (b *serviceAccount) NamespaceName(namespace, name string) *serviceAccount {
+	return b.Mutate(func(sa *corev1.ServiceAccount) {
 		sa.ObjectMeta.Namespace = namespace
 		sa.ObjectMeta.Name = name
 	})
 }
 
-func (f *serviceAccount) ObjectMeta(nf func(ObjectMeta)) *serviceAccount {
-	return f.Mutate(func(sa *corev1.ServiceAccount) {
+func (b *serviceAccount) ObjectMeta(nf func(ObjectMeta)) *serviceAccount {
+	return b.Mutate(func(sa *corev1.ServiceAccount) {
 		omf := objectMeta(sa.ObjectMeta)
 		nf(omf)
-		sa.ObjectMeta = omf.Get()
+		sa.ObjectMeta = omf.Build()
 	})
 }
 
-func (f *serviceAccount) Secrets(secrets ...string) *serviceAccount {
-	return f.Mutate(func(sa *corev1.ServiceAccount) {
+func (b *serviceAccount) Secrets(secrets ...string) *serviceAccount {
+	return b.Mutate(func(sa *corev1.ServiceAccount) {
 		sa.Secrets = make([]corev1.ObjectReference, len(secrets))
 		for i, secret := range secrets {
 			sa.Secrets[i] = corev1.ObjectReference{Name: secret}


### PR DESCRIPTION
The types in the "factories" package would more commonly be called (fluent)
builders.

The construction method `Get()` doesn't make it obvious whether a new instance
is being created or (unlikely but conceivable) a previously created instance
is being reused. Using builder terminology, a 'Build()' method has no
connotation of reusing something previously built.