### PR TITLE
Improve Mutate methods

### DIFF
--- a/pkg/controllers/testing/factories/adapter_knative.go
+++ b/pkg/controllers/testing/factories/adapter_knative.go
@@ -50,21 +50,21 @@ func (f *adapterKnative) Get() *knativev1alpha1.Adapter {
 	return f.deepCopy().target
 }
 
-func (f *adapterKnative) Mutate(m func(*knativev1alpha1.Adapter)) *adapterKnative {
+func (f *adapterKnative) mutation(m func(*knativev1alpha1.Adapter)) *adapterKnative {
 	f = f.deepCopy()
 	m(f.target)
 	return f
 }
 
 func (f *adapterKnative) NamespaceName(namespace, name string) *adapterKnative {
-	return f.Mutate(func(adapter *knativev1alpha1.Adapter) {
+	return f.mutation(func(adapter *knativev1alpha1.Adapter) {
 		adapter.ObjectMeta.Namespace = namespace
 		adapter.ObjectMeta.Name = name
 	})
 }
 
 func (f *adapterKnative) ObjectMeta(nf func(ObjectMeta)) *adapterKnative {
-	return f.Mutate(func(adapter *knativev1alpha1.Adapter) {
+	return f.mutation(func(adapter *knativev1alpha1.Adapter) {
 		omf := objectMeta(adapter.ObjectMeta)
 		nf(omf)
 		adapter.ObjectMeta = omf.Get()
@@ -72,7 +72,7 @@ func (f *adapterKnative) ObjectMeta(nf func(ObjectMeta)) *adapterKnative {
 }
 
 func (f *adapterKnative) ApplicationRef(format string, a ...interface{}) *adapterKnative {
-	return f.Mutate(func(adapter *knativev1alpha1.Adapter) {
+	return f.mutation(func(adapter *knativev1alpha1.Adapter) {
 		adapter.Spec.Build = knativev1alpha1.Build{
 			ApplicationRef: fmt.Sprintf(format, a...),
 		}
@@ -80,7 +80,7 @@ func (f *adapterKnative) ApplicationRef(format string, a ...interface{}) *adapte
 }
 
 func (f *adapterKnative) ContainerRef(format string, a ...interface{}) *adapterKnative {
-	return f.Mutate(func(adapter *knativev1alpha1.Adapter) {
+	return f.mutation(func(adapter *knativev1alpha1.Adapter) {
 		adapter.Spec.Build = knativev1alpha1.Build{
 			ContainerRef: fmt.Sprintf(format, a...),
 		}
@@ -88,7 +88,7 @@ func (f *adapterKnative) ContainerRef(format string, a ...interface{}) *adapterK
 }
 
 func (f *adapterKnative) FunctionRef(format string, a ...interface{}) *adapterKnative {
-	return f.Mutate(func(adapter *knativev1alpha1.Adapter) {
+	return f.mutation(func(adapter *knativev1alpha1.Adapter) {
 		adapter.Spec.Build = knativev1alpha1.Build{
 			FunctionRef: fmt.Sprintf(format, a...),
 		}
@@ -96,7 +96,7 @@ func (f *adapterKnative) FunctionRef(format string, a ...interface{}) *adapterKn
 }
 
 func (f *adapterKnative) ConfigurationRef(format string, a ...interface{}) *adapterKnative {
-	return f.Mutate(func(adapter *knativev1alpha1.Adapter) {
+	return f.mutation(func(adapter *knativev1alpha1.Adapter) {
 		adapter.Spec.Target = knativev1alpha1.AdapterTarget{
 			ConfigurationRef: fmt.Sprintf(format, a...),
 		}
@@ -104,7 +104,7 @@ func (f *adapterKnative) ConfigurationRef(format string, a ...interface{}) *adap
 }
 
 func (f *adapterKnative) ServiceRef(format string, a ...interface{}) *adapterKnative {
-	return f.Mutate(func(adapter *knativev1alpha1.Adapter) {
+	return f.mutation(func(adapter *knativev1alpha1.Adapter) {
 		adapter.Spec.Target = knativev1alpha1.AdapterTarget{
 			ServiceRef: fmt.Sprintf(format, a...),
 		}
@@ -112,7 +112,7 @@ func (f *adapterKnative) ServiceRef(format string, a ...interface{}) *adapterKna
 }
 
 func (f *adapterKnative) StatusConditions(conditions ...*condition) *adapterKnative {
-	return f.Mutate(func(adapter *knativev1alpha1.Adapter) {
+	return f.mutation(func(adapter *knativev1alpha1.Adapter) {
 		c := make([]apis.Condition, len(conditions))
 		for i, cg := range conditions {
 			c[i] = cg.Get()
@@ -122,13 +122,13 @@ func (f *adapterKnative) StatusConditions(conditions ...*condition) *adapterKnat
 }
 
 func (f *adapterKnative) StatusObservedGeneration(generation int64) *adapterKnative {
-	return f.Mutate(func(adapter *knativev1alpha1.Adapter) {
+	return f.mutation(func(adapter *knativev1alpha1.Adapter) {
 		adapter.Status.ObservedGeneration = generation
 	})
 }
 
 func (f *adapterKnative) StatusLatestImage(format string, a ...interface{}) *adapterKnative {
-	return f.Mutate(func(adapter *knativev1alpha1.Adapter) {
+	return f.mutation(func(adapter *knativev1alpha1.Adapter) {
 		adapter.Status.LatestImage = fmt.Sprintf(format, a...)
 	})
 }

--- a/pkg/controllers/testing/factories/application.go
+++ b/pkg/controllers/testing/factories/application.go
@@ -54,21 +54,21 @@ func (f *application) Get() *buildv1alpha1.Application {
 	return f.deepCopy().target
 }
 
-func (f *application) Mutate(m func(*buildv1alpha1.Application)) *application {
+func (f *application) mutation(m func(*buildv1alpha1.Application)) *application {
 	f = f.deepCopy()
 	m(f.target)
 	return f
 }
 
 func (f *application) NamespaceName(namespace, name string) *application {
-	return f.Mutate(func(app *buildv1alpha1.Application) {
+	return f.mutation(func(app *buildv1alpha1.Application) {
 		app.ObjectMeta.Namespace = namespace
 		app.ObjectMeta.Name = name
 	})
 }
 
 func (f *application) ObjectMeta(nf func(ObjectMeta)) *application {
-	return f.Mutate(func(app *buildv1alpha1.Application) {
+	return f.mutation(func(app *buildv1alpha1.Application) {
 		omf := objectMeta(app.ObjectMeta)
 		nf(omf)
 		app.ObjectMeta = omf.Get()
@@ -76,13 +76,13 @@ func (f *application) ObjectMeta(nf func(ObjectMeta)) *application {
 }
 
 func (f *application) Image(format string, a ...interface{}) *application {
-	return f.Mutate(func(app *buildv1alpha1.Application) {
+	return f.mutation(func(app *buildv1alpha1.Application) {
 		app.Spec.Image = fmt.Sprintf(format, a...)
 	})
 }
 
 func (f *application) SourceGit(url string, revision string) *application {
-	return f.Mutate(func(app *buildv1alpha1.Application) {
+	return f.mutation(func(app *buildv1alpha1.Application) {
 		if app.Spec.Source == nil {
 			app.Spec.Source = &buildv1alpha1.Source{}
 		}
@@ -97,7 +97,7 @@ func (f *application) SourceGit(url string, revision string) *application {
 }
 
 func (f *application) SourceSubPath(subpath string) *application {
-	return f.Mutate(func(app *buildv1alpha1.Application) {
+	return f.mutation(func(app *buildv1alpha1.Application) {
 		if app.Spec.Source == nil {
 			app.Spec.Source = &buildv1alpha1.Source{}
 		}
@@ -106,7 +106,7 @@ func (f *application) SourceSubPath(subpath string) *application {
 }
 
 func (f *application) BuildCache(quantity string) *application {
-	return f.Mutate(func(app *buildv1alpha1.Application) {
+	return f.mutation(func(app *buildv1alpha1.Application) {
 		size, err := resource.ParseQuantity(quantity)
 		if err != nil {
 			panic(err)
@@ -116,7 +116,7 @@ func (f *application) BuildCache(quantity string) *application {
 }
 
 func (f *application) StatusConditions(conditions ...*condition) *application {
-	return f.Mutate(func(app *buildv1alpha1.Application) {
+	return f.mutation(func(app *buildv1alpha1.Application) {
 		c := make([]apis.Condition, len(conditions))
 		for i, cg := range conditions {
 			c[i] = cg.Get()
@@ -132,13 +132,13 @@ func (f *application) StatusReady() *application {
 }
 
 func (f *application) StatusObservedGeneration(generation int64) *application {
-	return f.Mutate(func(app *buildv1alpha1.Application) {
+	return f.mutation(func(app *buildv1alpha1.Application) {
 		app.Status.ObservedGeneration = generation
 	})
 }
 
 func (f *application) StatusKpackImageRef(format string, a ...interface{}) *application {
-	return f.Mutate(func(app *buildv1alpha1.Application) {
+	return f.mutation(func(app *buildv1alpha1.Application) {
 		app.Status.KpackImageRef = &refs.TypedLocalObjectReference{
 			APIGroup: rtesting.StringPtr("build.pivotal.io"),
 			Kind:     "Image",
@@ -148,7 +148,7 @@ func (f *application) StatusKpackImageRef(format string, a ...interface{}) *appl
 }
 
 func (f *application) StatusBuildCacheRef(format string, a ...interface{}) *application {
-	return f.Mutate(func(app *buildv1alpha1.Application) {
+	return f.mutation(func(app *buildv1alpha1.Application) {
 		app.Status.BuildCacheRef = &refs.TypedLocalObjectReference{
 			Kind: "PersistentVolumeClaim",
 			Name: fmt.Sprintf(format, a...),
@@ -157,13 +157,13 @@ func (f *application) StatusBuildCacheRef(format string, a ...interface{}) *appl
 }
 
 func (f *application) StatusTargetImage(format string, a ...interface{}) *application {
-	return f.Mutate(func(app *buildv1alpha1.Application) {
+	return f.mutation(func(app *buildv1alpha1.Application) {
 		app.Status.TargetImage = fmt.Sprintf(format, a...)
 	})
 }
 
 func (f *application) StatusLatestImage(format string, a ...interface{}) *application {
-	return f.Mutate(func(app *buildv1alpha1.Application) {
+	return f.mutation(func(app *buildv1alpha1.Application) {
 		app.Status.LatestImage = fmt.Sprintf(format, a...)
 	})
 }

--- a/pkg/controllers/testing/factories/condition.go
+++ b/pkg/controllers/testing/factories/condition.go
@@ -51,26 +51,26 @@ func (f *condition) Get() apis.Condition {
 	return *f.deepCopy().target
 }
 
-func (f *condition) Mutate(m func(*apis.Condition)) *condition {
+func (f *condition) mutation(m func(*apis.Condition)) *condition {
 	f = f.deepCopy()
 	m(f.target)
 	return f
 }
 
 func (f *condition) Type(t apis.ConditionType) *condition {
-	return f.Mutate(func(c *apis.Condition) {
+	return f.mutation(func(c *apis.Condition) {
 		c.Type = t
 	})
 }
 
 func (f *condition) Unknown() *condition {
-	return f.Mutate(func(c *apis.Condition) {
+	return f.mutation(func(c *apis.Condition) {
 		c.Status = corev1.ConditionUnknown
 	})
 }
 
 func (f *condition) True() *condition {
-	return f.Mutate(func(c *apis.Condition) {
+	return f.mutation(func(c *apis.Condition) {
 		c.Status = corev1.ConditionTrue
 		c.Reason = ""
 		c.Message = ""
@@ -78,32 +78,32 @@ func (f *condition) True() *condition {
 }
 
 func (f *condition) False() *condition {
-	return f.Mutate(func(c *apis.Condition) {
+	return f.mutation(func(c *apis.Condition) {
 		c.Status = corev1.ConditionFalse
 	})
 }
 
 func (f *condition) Reason(reason, message string) *condition {
-	return f.Mutate(func(c *apis.Condition) {
+	return f.mutation(func(c *apis.Condition) {
 		c.Reason = reason
 		c.Message = message
 	})
 }
 
 func (f *condition) Info() *condition {
-	return f.Mutate(func(c *apis.Condition) {
+	return f.mutation(func(c *apis.Condition) {
 		c.Severity = apis.ConditionSeverityInfo
 	})
 }
 
 func (f *condition) Warning() *condition {
-	return f.Mutate(func(c *apis.Condition) {
+	return f.mutation(func(c *apis.Condition) {
 		c.Severity = apis.ConditionSeverityWarning
 	})
 }
 
 func (f *condition) Error() *condition {
-	return f.Mutate(func(c *apis.Condition) {
+	return f.mutation(func(c *apis.Condition) {
 		c.Severity = apis.ConditionSeverityError
 	})
 }

--- a/pkg/controllers/testing/factories/configmap.go
+++ b/pkg/controllers/testing/factories/configmap.go
@@ -49,21 +49,21 @@ func (f *configMap) Get() *corev1.ConfigMap {
 	return f.deepCopy().target
 }
 
-func (f *configMap) Mutate(m func(*corev1.ConfigMap)) *configMap {
+func (f *configMap) mutation(m func(*corev1.ConfigMap)) *configMap {
 	f = f.deepCopy()
 	m(f.target)
 	return f
 }
 
 func (f *configMap) NamespaceName(namespace, name string) *configMap {
-	return f.Mutate(func(cm *corev1.ConfigMap) {
+	return f.mutation(func(cm *corev1.ConfigMap) {
 		cm.ObjectMeta.Namespace = namespace
 		cm.ObjectMeta.Name = name
 	})
 }
 
 func (f *configMap) ObjectMeta(nf func(ObjectMeta)) *configMap {
-	return f.Mutate(func(cm *corev1.ConfigMap) {
+	return f.mutation(func(cm *corev1.ConfigMap) {
 		omf := objectMeta(cm.ObjectMeta)
 		nf(omf)
 		cm.ObjectMeta = omf.Get()
@@ -71,7 +71,7 @@ func (f *configMap) ObjectMeta(nf func(ObjectMeta)) *configMap {
 }
 
 func (f *configMap) AddData(key, value string) *configMap {
-	return f.Mutate(func(cm *corev1.ConfigMap) {
+	return f.mutation(func(cm *corev1.ConfigMap) {
 		if cm.Data == nil {
 			cm.Data = map[string]string{}
 		}

--- a/pkg/controllers/testing/factories/container.go
+++ b/pkg/controllers/testing/factories/container.go
@@ -50,21 +50,21 @@ func (f *container) Get() *buildv1alpha1.Container {
 	return f.deepCopy().target
 }
 
-func (f *container) Mutate(m func(*buildv1alpha1.Container)) *container {
+func (f *container) mutation(m func(*buildv1alpha1.Container)) *container {
 	f = f.deepCopy()
 	m(f.target)
 	return f
 }
 
 func (f *container) NamespaceName(namespace, name string) *container {
-	return f.Mutate(func(con *buildv1alpha1.Container) {
+	return f.mutation(func(con *buildv1alpha1.Container) {
 		con.ObjectMeta.Namespace = namespace
 		con.ObjectMeta.Name = name
 	})
 }
 
 func (f *container) ObjectMeta(nf func(ObjectMeta)) *container {
-	return f.Mutate(func(con *buildv1alpha1.Container) {
+	return f.mutation(func(con *buildv1alpha1.Container) {
 		omf := objectMeta(con.ObjectMeta)
 		nf(omf)
 		con.ObjectMeta = omf.Get()
@@ -72,13 +72,13 @@ func (f *container) ObjectMeta(nf func(ObjectMeta)) *container {
 }
 
 func (f *container) Image(format string, a ...interface{}) *container {
-	return f.Mutate(func(con *buildv1alpha1.Container) {
+	return f.mutation(func(con *buildv1alpha1.Container) {
 		con.Spec.Image = fmt.Sprintf(format, a...)
 	})
 }
 
 func (f *container) StatusConditions(conditions ...*condition) *container {
-	return f.Mutate(func(con *buildv1alpha1.Container) {
+	return f.mutation(func(con *buildv1alpha1.Container) {
 		c := make([]apis.Condition, len(conditions))
 		for i, cg := range conditions {
 			c[i] = cg.Get()
@@ -94,19 +94,19 @@ func (f *container) StatusReady() *container {
 }
 
 func (f *container) StatusObservedGeneration(generation int64) *container {
-	return f.Mutate(func(con *buildv1alpha1.Container) {
+	return f.mutation(func(con *buildv1alpha1.Container) {
 		con.Status.ObservedGeneration = generation
 	})
 }
 
 func (f *container) StatusTargetImage(format string, a ...interface{}) *container {
-	return f.Mutate(func(con *buildv1alpha1.Container) {
+	return f.mutation(func(con *buildv1alpha1.Container) {
 		con.Status.TargetImage = fmt.Sprintf(format, a...)
 	})
 }
 
 func (f *container) StatusLatestImage(format string, a ...interface{}) *container {
-	return f.Mutate(func(con *buildv1alpha1.Container) {
+	return f.mutation(func(con *buildv1alpha1.Container) {
 		con.Status.LatestImage = fmt.Sprintf(format, a...)
 	})
 }

--- a/pkg/controllers/testing/factories/deployer_core.go
+++ b/pkg/controllers/testing/factories/deployer_core.go
@@ -54,21 +54,21 @@ func (f *deployerCore) Get() *corev1alpha1.Deployer {
 	return f.deepCopy().target
 }
 
-func (f *deployerCore) Mutate(m func(*corev1alpha1.Deployer)) *deployerCore {
+func (f *deployerCore) mutation(m func(*corev1alpha1.Deployer)) *deployerCore {
 	f = f.deepCopy()
 	m(f.target)
 	return f
 }
 
 func (f *deployerCore) NamespaceName(namespace, name string) *deployerCore {
-	return f.Mutate(func(deployer *corev1alpha1.Deployer) {
+	return f.mutation(func(deployer *corev1alpha1.Deployer) {
 		deployer.ObjectMeta.Namespace = namespace
 		deployer.ObjectMeta.Name = name
 	})
 }
 
 func (f *deployerCore) ObjectMeta(nf func(ObjectMeta)) *deployerCore {
-	return f.Mutate(func(deployer *corev1alpha1.Deployer) {
+	return f.mutation(func(deployer *corev1alpha1.Deployer) {
 		omf := objectMeta(deployer.ObjectMeta)
 		nf(omf)
 		deployer.ObjectMeta = omf.Get()
@@ -76,7 +76,7 @@ func (f *deployerCore) ObjectMeta(nf func(ObjectMeta)) *deployerCore {
 }
 
 func (f *deployerCore) PodTemplateSpec(nf func(PodTemplateSpec)) *deployerCore {
-	return f.Mutate(func(deployer *corev1alpha1.Deployer) {
+	return f.mutation(func(deployer *corev1alpha1.Deployer) {
 		if deployer.Spec.Template == nil {
 			deployer.Spec.Template = &corev1.PodTemplateSpec{}
 		}
@@ -94,7 +94,7 @@ func (f *deployerCore) HandlerContainer(cb func(*corev1.Container)) *deployerCor
 }
 
 func (f *deployerCore) ApplicationRef(format string, a ...interface{}) *deployerCore {
-	return f.Mutate(func(deployer *corev1alpha1.Deployer) {
+	return f.mutation(func(deployer *corev1alpha1.Deployer) {
 		deployer.Spec.Build = &corev1alpha1.Build{
 			ApplicationRef: fmt.Sprintf(format, a...),
 		}
@@ -102,7 +102,7 @@ func (f *deployerCore) ApplicationRef(format string, a ...interface{}) *deployer
 }
 
 func (f *deployerCore) ContainerRef(format string, a ...interface{}) *deployerCore {
-	return f.Mutate(func(deployer *corev1alpha1.Deployer) {
+	return f.mutation(func(deployer *corev1alpha1.Deployer) {
 		deployer.Spec.Build = &corev1alpha1.Build{
 			ContainerRef: fmt.Sprintf(format, a...),
 		}
@@ -110,7 +110,7 @@ func (f *deployerCore) ContainerRef(format string, a ...interface{}) *deployerCo
 }
 
 func (f *deployerCore) FunctionRef(format string, a ...interface{}) *deployerCore {
-	return f.Mutate(func(deployer *corev1alpha1.Deployer) {
+	return f.mutation(func(deployer *corev1alpha1.Deployer) {
 		deployer.Spec.Build = &corev1alpha1.Build{
 			FunctionRef: fmt.Sprintf(format, a...),
 		}
@@ -124,13 +124,13 @@ func (f *deployerCore) Image(format string, a ...interface{}) *deployerCore {
 }
 
 func (f *deployerCore) IngressPolicy(policy corev1alpha1.IngressPolicy) *deployerCore {
-	return f.Mutate(func(deployer *corev1alpha1.Deployer) {
+	return f.mutation(func(deployer *corev1alpha1.Deployer) {
 		deployer.Spec.IngressPolicy = policy
 	})
 }
 
 func (f *deployerCore) StatusConditions(conditions ...*condition) *deployerCore {
-	return f.Mutate(func(deployer *corev1alpha1.Deployer) {
+	return f.mutation(func(deployer *corev1alpha1.Deployer) {
 		c := make([]apis.Condition, len(conditions))
 		for i, cg := range conditions {
 			c[i] = cg.Get()
@@ -140,19 +140,19 @@ func (f *deployerCore) StatusConditions(conditions ...*condition) *deployerCore 
 }
 
 func (f *deployerCore) StatusObservedGeneration(generation int64) *deployerCore {
-	return f.Mutate(func(deployer *corev1alpha1.Deployer) {
+	return f.mutation(func(deployer *corev1alpha1.Deployer) {
 		deployer.Status.ObservedGeneration = generation
 	})
 }
 
 func (f *deployerCore) StatusLatestImage(format string, a ...interface{}) *deployerCore {
-	return f.Mutate(func(deployer *corev1alpha1.Deployer) {
+	return f.mutation(func(deployer *corev1alpha1.Deployer) {
 		deployer.Status.LatestImage = fmt.Sprintf(format, a...)
 	})
 }
 
 func (f *deployerCore) StatusDeploymentRef(format string, a ...interface{}) *deployerCore {
-	return f.Mutate(func(deployer *corev1alpha1.Deployer) {
+	return f.mutation(func(deployer *corev1alpha1.Deployer) {
 		deployer.Status.DeploymentRef = &refs.TypedLocalObjectReference{
 			APIGroup: rtesting.StringPtr("apps"),
 			Kind:     "Deployment",
@@ -162,7 +162,7 @@ func (f *deployerCore) StatusDeploymentRef(format string, a ...interface{}) *dep
 }
 
 func (f *deployerCore) StatusServiceRef(format string, a ...interface{}) *deployerCore {
-	return f.Mutate(func(deployer *corev1alpha1.Deployer) {
+	return f.mutation(func(deployer *corev1alpha1.Deployer) {
 		deployer.Status.ServiceRef = &refs.TypedLocalObjectReference{
 			APIGroup: nil,
 			Kind:     "Service",
@@ -172,7 +172,7 @@ func (f *deployerCore) StatusServiceRef(format string, a ...interface{}) *deploy
 }
 
 func (f *deployerCore) StatusIngressRef(format string, a ...interface{}) *deployerCore {
-	return f.Mutate(func(deployer *corev1alpha1.Deployer) {
+	return f.mutation(func(deployer *corev1alpha1.Deployer) {
 		deployer.Status.IngressRef = &refs.TypedLocalObjectReference{
 			APIGroup: rtesting.StringPtr("networking.k8s.io"),
 			Kind:     "Ingress",
@@ -182,7 +182,7 @@ func (f *deployerCore) StatusIngressRef(format string, a ...interface{}) *deploy
 }
 
 func (f *deployerCore) StatusAddressURL(format string, a ...interface{}) *deployerCore {
-	return f.Mutate(func(deployer *corev1alpha1.Deployer) {
+	return f.mutation(func(deployer *corev1alpha1.Deployer) {
 		deployer.Status.Address = &apis.Addressable{
 			URL: fmt.Sprintf(format, a...),
 		}
@@ -190,7 +190,7 @@ func (f *deployerCore) StatusAddressURL(format string, a ...interface{}) *deploy
 }
 
 func (f *deployerCore) StatusURL(format string, a ...interface{}) *deployerCore {
-	return f.Mutate(func(deployer *corev1alpha1.Deployer) {
+	return f.mutation(func(deployer *corev1alpha1.Deployer) {
 		deployer.Status.URL = fmt.Sprintf(format, a...)
 	})
 }

--- a/pkg/controllers/testing/factories/deployer_knative.go
+++ b/pkg/controllers/testing/factories/deployer_knative.go
@@ -54,21 +54,21 @@ func (f *deployerKnative) Get() *knativev1alpha1.Deployer {
 	return f.deepCopy().target
 }
 
-func (f *deployerKnative) Mutate(m func(*knativev1alpha1.Deployer)) *deployerKnative {
+func (f *deployerKnative) mutation(m func(*knativev1alpha1.Deployer)) *deployerKnative {
 	f = f.deepCopy()
 	m(f.target)
 	return f
 }
 
 func (f *deployerKnative) NamespaceName(namespace, name string) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+	return f.mutation(func(deployer *knativev1alpha1.Deployer) {
 		deployer.ObjectMeta.Namespace = namespace
 		deployer.ObjectMeta.Name = name
 	})
 }
 
 func (f *deployerKnative) ObjectMeta(nf func(ObjectMeta)) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+	return f.mutation(func(deployer *knativev1alpha1.Deployer) {
 		omf := objectMeta(deployer.ObjectMeta)
 		nf(omf)
 		deployer.ObjectMeta = omf.Get()
@@ -76,7 +76,7 @@ func (f *deployerKnative) ObjectMeta(nf func(ObjectMeta)) *deployerKnative {
 }
 
 func (f *deployerKnative) PodTemplateSpec(nf func(PodTemplateSpec)) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+	return f.mutation(func(deployer *knativev1alpha1.Deployer) {
 		if deployer.Spec.Template == nil {
 			deployer.Spec.Template = &corev1.PodTemplateSpec{}
 		}
@@ -88,7 +88,7 @@ func (f *deployerKnative) PodTemplateSpec(nf func(PodTemplateSpec)) *deployerKna
 }
 
 func (f *deployerKnative) ApplicationRef(format string, a ...interface{}) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+	return f.mutation(func(deployer *knativev1alpha1.Deployer) {
 		deployer.Spec.Build = &knativev1alpha1.Build{
 			ApplicationRef: fmt.Sprintf(format, a...),
 		}
@@ -96,7 +96,7 @@ func (f *deployerKnative) ApplicationRef(format string, a ...interface{}) *deplo
 }
 
 func (f *deployerKnative) ContainerRef(format string, a ...interface{}) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+	return f.mutation(func(deployer *knativev1alpha1.Deployer) {
 		deployer.Spec.Build = &knativev1alpha1.Build{
 			ContainerRef: fmt.Sprintf(format, a...),
 		}
@@ -104,7 +104,7 @@ func (f *deployerKnative) ContainerRef(format string, a ...interface{}) *deploye
 }
 
 func (f *deployerKnative) FunctionRef(format string, a ...interface{}) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+	return f.mutation(func(deployer *knativev1alpha1.Deployer) {
 		deployer.Spec.Build = &knativev1alpha1.Build{
 			FunctionRef: fmt.Sprintf(format, a...),
 		}
@@ -120,25 +120,25 @@ func (f *deployerKnative) Image(format string, a ...interface{}) *deployerKnativ
 }
 
 func (f *deployerKnative) IngressPolicy(policy knativev1alpha1.IngressPolicy) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+	return f.mutation(func(deployer *knativev1alpha1.Deployer) {
 		deployer.Spec.IngressPolicy = policy
 	})
 }
 
 func (f *deployerKnative) MinScale(scale int32) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+	return f.mutation(func(deployer *knativev1alpha1.Deployer) {
 		deployer.Spec.Scale.Min = &scale
 	})
 }
 
 func (f *deployerKnative) MaxScale(scale int32) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+	return f.mutation(func(deployer *knativev1alpha1.Deployer) {
 		deployer.Spec.Scale.Max = &scale
 	})
 }
 
 func (f *deployerKnative) StatusConditions(conditions ...*condition) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+	return f.mutation(func(deployer *knativev1alpha1.Deployer) {
 		c := make([]apis.Condition, len(conditions))
 		for i, cg := range conditions {
 			c[i] = cg.Get()
@@ -148,19 +148,19 @@ func (f *deployerKnative) StatusConditions(conditions ...*condition) *deployerKn
 }
 
 func (f *deployerKnative) StatusObservedGeneration(generation int64) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+	return f.mutation(func(deployer *knativev1alpha1.Deployer) {
 		deployer.Status.ObservedGeneration = generation
 	})
 }
 
 func (f *deployerKnative) StatusLatestImage(format string, a ...interface{}) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+	return f.mutation(func(deployer *knativev1alpha1.Deployer) {
 		deployer.Status.LatestImage = fmt.Sprintf(format, a...)
 	})
 }
 
 func (f *deployerKnative) StatusConfigurationRef(format string, a ...interface{}) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+	return f.mutation(func(deployer *knativev1alpha1.Deployer) {
 		deployer.Status.ConfigurationRef = &refs.TypedLocalObjectReference{
 			APIGroup: rtesting.StringPtr("serving.knative.dev"),
 			Kind:     "Configuration",
@@ -170,7 +170,7 @@ func (f *deployerKnative) StatusConfigurationRef(format string, a ...interface{}
 }
 
 func (f *deployerKnative) StatusRouteRef(format string, a ...interface{}) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+	return f.mutation(func(deployer *knativev1alpha1.Deployer) {
 		deployer.Status.RouteRef = &refs.TypedLocalObjectReference{
 			APIGroup: rtesting.StringPtr("serving.knative.dev"),
 			Kind:     "Route",
@@ -180,7 +180,7 @@ func (f *deployerKnative) StatusRouteRef(format string, a ...interface{}) *deplo
 }
 
 func (f *deployerKnative) StatusAddressURL(url string) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+	return f.mutation(func(deployer *knativev1alpha1.Deployer) {
 		deployer.Status.Address = &apis.Addressable{
 			URL: url,
 		}
@@ -188,7 +188,7 @@ func (f *deployerKnative) StatusAddressURL(url string) *deployerKnative {
 }
 
 func (f *deployerKnative) StatusURL(url string) *deployerKnative {
-	return f.Mutate(func(deployer *knativev1alpha1.Deployer) {
+	return f.mutation(func(deployer *knativev1alpha1.Deployer) {
 		deployer.Status.URL = url
 	})
 }

--- a/pkg/controllers/testing/factories/deployment.go
+++ b/pkg/controllers/testing/factories/deployment.go
@@ -53,21 +53,21 @@ func (f *deployment) Get() *appsv1.Deployment {
 	return f.deepCopy().target
 }
 
-func (f *deployment) Mutate(m func(*appsv1.Deployment)) *deployment {
+func (f *deployment) mutation(m func(*appsv1.Deployment)) *deployment {
 	f = f.deepCopy()
 	m(f.target)
 	return f
 }
 
 func (f *deployment) NamespaceName(namespace, name string) *deployment {
-	return f.Mutate(func(sa *appsv1.Deployment) {
+	return f.mutation(func(sa *appsv1.Deployment) {
 		sa.ObjectMeta.Namespace = namespace
 		sa.ObjectMeta.Name = name
 	})
 }
 
 func (f *deployment) ObjectMeta(nf func(ObjectMeta)) *deployment {
-	return f.Mutate(func(sa *appsv1.Deployment) {
+	return f.mutation(func(sa *appsv1.Deployment) {
 		omf := objectMeta(sa.ObjectMeta)
 		nf(omf)
 		sa.ObjectMeta = omf.Get()
@@ -75,7 +75,7 @@ func (f *deployment) ObjectMeta(nf func(ObjectMeta)) *deployment {
 }
 
 func (f *deployment) PodTemplateSpec(nf func(PodTemplateSpec)) *deployment {
-	return f.Mutate(func(deployment *appsv1.Deployment) {
+	return f.mutation(func(deployment *appsv1.Deployment) {
 		ptsf := podTemplateSpec(deployment.Spec.Template)
 		nf(ptsf)
 		deployment.Spec.Template = ptsf.Get()
@@ -89,13 +89,13 @@ func (f *deployment) HandlerContainer(cb func(*corev1.Container)) *deployment {
 }
 
 func (f *deployment) Replicas(replicas int32) *deployment {
-	return f.Mutate(func(deployment *appsv1.Deployment) {
+	return f.mutation(func(deployment *appsv1.Deployment) {
 		deployment.Spec.Replicas = rtesting.Int32Ptr(replicas)
 	})
 }
 
 func (f *deployment) AddSelectorLabel(key, value string) *deployment {
-	return f.Mutate(func(deployment *appsv1.Deployment) {
+	return f.mutation(func(deployment *appsv1.Deployment) {
 		if deployment.Spec.Selector == nil {
 			deployment.Spec.Selector = &metav1.LabelSelector{}
 		}
@@ -105,7 +105,7 @@ func (f *deployment) AddSelectorLabel(key, value string) *deployment {
 }
 
 func (f *deployment) StatusConditions(conditions ...*condition) *deployment {
-	return f.Mutate(func(deployment *appsv1.Deployment) {
+	return f.mutation(func(deployment *appsv1.Deployment) {
 		c := make([]appsv1.DeploymentCondition, len(conditions))
 		for i, cg := range conditions {
 			dc := cg.Get()

--- a/pkg/controllers/testing/factories/function.go
+++ b/pkg/controllers/testing/factories/function.go
@@ -54,21 +54,21 @@ func (f *function) Get() *buildv1alpha1.Function {
 	return f.deepCopy().target
 }
 
-func (f *function) Mutate(m func(*buildv1alpha1.Function)) *function {
+func (f *function) mutation(m func(*buildv1alpha1.Function)) *function {
 	f = f.deepCopy()
 	m(f.target)
 	return f
 }
 
 func (f *function) NamespaceName(namespace, name string) *function {
-	return f.Mutate(func(fn *buildv1alpha1.Function) {
+	return f.mutation(func(fn *buildv1alpha1.Function) {
 		fn.ObjectMeta.Namespace = namespace
 		fn.ObjectMeta.Name = name
 	})
 }
 
 func (f *function) ObjectMeta(nf func(ObjectMeta)) *function {
-	return f.Mutate(func(fn *buildv1alpha1.Function) {
+	return f.mutation(func(fn *buildv1alpha1.Function) {
 		omf := objectMeta(fn.ObjectMeta)
 		nf(omf)
 		fn.ObjectMeta = omf.Get()
@@ -76,31 +76,31 @@ func (f *function) ObjectMeta(nf func(ObjectMeta)) *function {
 }
 
 func (f *function) Image(format string, a ...interface{}) *function {
-	return f.Mutate(func(fn *buildv1alpha1.Function) {
+	return f.mutation(func(fn *buildv1alpha1.Function) {
 		fn.Spec.Image = fmt.Sprintf(format, a...)
 	})
 }
 
 func (f *function) Artifact(artifact string) *function {
-	return f.Mutate(func(fn *buildv1alpha1.Function) {
+	return f.mutation(func(fn *buildv1alpha1.Function) {
 		fn.Spec.Artifact = artifact
 	})
 }
 
 func (f *function) Handler(handler string) *function {
-	return f.Mutate(func(fn *buildv1alpha1.Function) {
+	return f.mutation(func(fn *buildv1alpha1.Function) {
 		fn.Spec.Handler = handler
 	})
 }
 
 func (f *function) Invoker(invoker string) *function {
-	return f.Mutate(func(fn *buildv1alpha1.Function) {
+	return f.mutation(func(fn *buildv1alpha1.Function) {
 		fn.Spec.Invoker = invoker
 	})
 }
 
 func (f *function) SourceGit(url string, revision string) *function {
-	return f.Mutate(func(fn *buildv1alpha1.Function) {
+	return f.mutation(func(fn *buildv1alpha1.Function) {
 		if fn.Spec.Source == nil {
 			fn.Spec.Source = &buildv1alpha1.Source{}
 		}
@@ -115,7 +115,7 @@ func (f *function) SourceGit(url string, revision string) *function {
 }
 
 func (f *function) SourceSubPath(subpath string) *function {
-	return f.Mutate(func(fn *buildv1alpha1.Function) {
+	return f.mutation(func(fn *buildv1alpha1.Function) {
 		if fn.Spec.Source == nil {
 			fn.Spec.Source = &buildv1alpha1.Source{}
 		}
@@ -124,7 +124,7 @@ func (f *function) SourceSubPath(subpath string) *function {
 }
 
 func (f *function) BuildCache(quantity string) *function {
-	return f.Mutate(func(fn *buildv1alpha1.Function) {
+	return f.mutation(func(fn *buildv1alpha1.Function) {
 		size, err := resource.ParseQuantity(quantity)
 		if err != nil {
 			panic(err)
@@ -134,7 +134,7 @@ func (f *function) BuildCache(quantity string) *function {
 }
 
 func (f *function) StatusConditions(conditions ...*condition) *function {
-	return f.Mutate(func(fn *buildv1alpha1.Function) {
+	return f.mutation(func(fn *buildv1alpha1.Function) {
 		c := make([]apis.Condition, len(conditions))
 		for i, cg := range conditions {
 			c[i] = cg.Get()
@@ -150,13 +150,13 @@ func (f *function) StatusReady() *function {
 }
 
 func (f *function) StatusObservedGeneration(generation int64) *function {
-	return f.Mutate(func(fn *buildv1alpha1.Function) {
+	return f.mutation(func(fn *buildv1alpha1.Function) {
 		fn.Status.ObservedGeneration = generation
 	})
 }
 
 func (f *function) StatusKpackImageRef(format string, a ...interface{}) *function {
-	return f.Mutate(func(fn *buildv1alpha1.Function) {
+	return f.mutation(func(fn *buildv1alpha1.Function) {
 		fn.Status.KpackImageRef = &refs.TypedLocalObjectReference{
 			APIGroup: rtesting.StringPtr("build.pivotal.io"),
 			Kind:     "Image",
@@ -166,7 +166,7 @@ func (f *function) StatusKpackImageRef(format string, a ...interface{}) *functio
 }
 
 func (f *function) StatusBuildCacheRef(format string, a ...interface{}) *function {
-	return f.Mutate(func(fn *buildv1alpha1.Function) {
+	return f.mutation(func(fn *buildv1alpha1.Function) {
 		fn.Status.BuildCacheRef = &refs.TypedLocalObjectReference{
 			Kind: "PersistentVolumeClaim",
 			Name: fmt.Sprintf(format, a...),
@@ -175,13 +175,13 @@ func (f *function) StatusBuildCacheRef(format string, a ...interface{}) *functio
 }
 
 func (f *function) StatusTargetImage(format string, a ...interface{}) *function {
-	return f.Mutate(func(fn *buildv1alpha1.Function) {
+	return f.mutation(func(fn *buildv1alpha1.Function) {
 		fn.Status.TargetImage = fmt.Sprintf(format, a...)
 	})
 }
 
 func (f *function) StatusLatestImage(format string, a ...interface{}) *function {
-	return f.Mutate(func(fn *buildv1alpha1.Function) {
+	return f.mutation(func(fn *buildv1alpha1.Function) {
 		fn.Status.LatestImage = fmt.Sprintf(format, a...)
 	})
 }

--- a/pkg/controllers/testing/factories/ingress.go
+++ b/pkg/controllers/testing/factories/ingress.go
@@ -51,21 +51,21 @@ func (f *ingress) Get() *networkingv1beta1.Ingress {
 	return f.deepCopy().target
 }
 
-func (f *ingress) Mutate(m func(*networkingv1beta1.Ingress)) *ingress {
+func (f *ingress) mutation(m func(*networkingv1beta1.Ingress)) *ingress {
 	f = f.deepCopy()
 	m(f.target)
 	return f
 }
 
 func (f *ingress) NamespaceName(namespace, name string) *ingress {
-	return f.Mutate(func(sa *networkingv1beta1.Ingress) {
+	return f.mutation(func(sa *networkingv1beta1.Ingress) {
 		sa.ObjectMeta.Namespace = namespace
 		sa.ObjectMeta.Name = name
 	})
 }
 
 func (f *ingress) ObjectMeta(nf func(ObjectMeta)) *ingress {
-	return f.Mutate(func(sa *networkingv1beta1.Ingress) {
+	return f.mutation(func(sa *networkingv1beta1.Ingress) {
 		omf := objectMeta(sa.ObjectMeta)
 		nf(omf)
 		sa.ObjectMeta = omf.Get()
@@ -73,7 +73,7 @@ func (f *ingress) ObjectMeta(nf func(ObjectMeta)) *ingress {
 }
 
 func (f *ingress) HostToService(host, serviceName string) *ingress {
-	return f.Mutate(func(i *networkingv1beta1.Ingress) {
+	return f.mutation(func(i *networkingv1beta1.Ingress) {
 		i.Spec = networkingv1beta1.IngressSpec{
 			Rules: []networkingv1beta1.IngressRule{{
 				Host: host,
@@ -94,7 +94,7 @@ func (f *ingress) HostToService(host, serviceName string) *ingress {
 }
 
 func (f *ingress) StatusLoadBalancer(ingress ...corev1.LoadBalancerIngress) *ingress {
-	return f.Mutate(func(i *networkingv1beta1.Ingress) {
+	return f.mutation(func(i *networkingv1beta1.Ingress) {
 		i.Status.LoadBalancer.Ingress = ingress
 	})
 }

--- a/pkg/controllers/testing/factories/keda_scaledobject.go
+++ b/pkg/controllers/testing/factories/keda_scaledobject.go
@@ -49,21 +49,21 @@ func (f *kedaScaledObject) Get() *kedav1alpha1.ScaledObject {
 	return f.deepCopy().target
 }
 
-func (f *kedaScaledObject) Mutate(m func(*kedav1alpha1.ScaledObject)) *kedaScaledObject {
+func (f *kedaScaledObject) mutation(m func(*kedav1alpha1.ScaledObject)) *kedaScaledObject {
 	f = f.deepCopy()
 	m(f.target)
 	return f
 }
 
 func (f *kedaScaledObject) NamespaceName(namespace, name string) *kedaScaledObject {
-	return f.Mutate(func(s *kedav1alpha1.ScaledObject) {
+	return f.mutation(func(s *kedav1alpha1.ScaledObject) {
 		s.ObjectMeta.Namespace = namespace
 		s.ObjectMeta.Name = name
 	})
 }
 
 func (f *kedaScaledObject) ObjectMeta(nf func(ObjectMeta)) *kedaScaledObject {
-	return f.Mutate(func(s *kedav1alpha1.ScaledObject) {
+	return f.mutation(func(s *kedav1alpha1.ScaledObject) {
 		omf := objectMeta(s.ObjectMeta)
 		nf(omf)
 		s.ObjectMeta = omf.Get()
@@ -71,37 +71,37 @@ func (f *kedaScaledObject) ObjectMeta(nf func(ObjectMeta)) *kedaScaledObject {
 }
 
 func (f *kedaScaledObject) Spec(spec *kedav1alpha1.ScaledObjectSpec) *kedaScaledObject {
-	return f.Mutate(func(s *kedav1alpha1.ScaledObject) {
+	return f.mutation(func(s *kedav1alpha1.ScaledObject) {
 		s.Spec = *spec
 	})
 }
 
 func (f *kedaScaledObject) ScaleTargetRefDeployment(format string, a ...interface{}) *kedaScaledObject {
-	return f.Mutate(func(s *kedav1alpha1.ScaledObject) {
+	return f.mutation(func(s *kedav1alpha1.ScaledObject) {
 		s.Spec.ScaleTargetRef = &kedav1alpha1.ObjectReference{DeploymentName: fmt.Sprintf(format, a...)}
 	})
 }
 
 func (f *kedaScaledObject) PollingInterval(pollingInterval int32) *kedaScaledObject {
-	return f.Mutate(func(s *kedav1alpha1.ScaledObject) {
+	return f.mutation(func(s *kedav1alpha1.ScaledObject) {
 		s.Spec.PollingInterval = &pollingInterval
 	})
 }
 
 func (f *kedaScaledObject) CooldownPeriod(cooldownPeriod int32) *kedaScaledObject {
-	return f.Mutate(func(s *kedav1alpha1.ScaledObject) {
+	return f.mutation(func(s *kedav1alpha1.ScaledObject) {
 		s.Spec.CooldownPeriod = &cooldownPeriod
 	})
 }
 
 func (f *kedaScaledObject) MinReplicaCount(minReplicaCount int32) *kedaScaledObject {
-	return f.Mutate(func(s *kedav1alpha1.ScaledObject) {
+	return f.mutation(func(s *kedav1alpha1.ScaledObject) {
 		s.Spec.MinReplicaCount = &minReplicaCount
 	})
 }
 
 func (f *kedaScaledObject) MaxReplicaCount(maxReplicaCount int32) *kedaScaledObject {
-	return f.Mutate(func(s *kedav1alpha1.ScaledObject) {
+	return f.mutation(func(s *kedav1alpha1.ScaledObject) {
 		s.Spec.MaxReplicaCount = &maxReplicaCount
 	})
 }

--- a/pkg/controllers/testing/factories/knative_configuration.go
+++ b/pkg/controllers/testing/factories/knative_configuration.go
@@ -52,21 +52,21 @@ func (f *knativeConfiguration) Get() *knativeservingv1.Configuration {
 	return f.deepCopy().target
 }
 
-func (f *knativeConfiguration) Mutate(m func(*knativeservingv1.Configuration)) *knativeConfiguration {
+func (f *knativeConfiguration) mutation(m func(*knativeservingv1.Configuration)) *knativeConfiguration {
 	f = f.deepCopy()
 	m(f.target)
 	return f
 }
 
 func (f *knativeConfiguration) NamespaceName(namespace, name string) *knativeConfiguration {
-	return f.Mutate(func(configuration *knativeservingv1.Configuration) {
+	return f.mutation(func(configuration *knativeservingv1.Configuration) {
 		configuration.ObjectMeta.Namespace = namespace
 		configuration.ObjectMeta.Name = name
 	})
 }
 
 func (f *knativeConfiguration) ObjectMeta(nf func(ObjectMeta)) *knativeConfiguration {
-	return f.Mutate(func(configuration *knativeservingv1.Configuration) {
+	return f.mutation(func(configuration *knativeservingv1.Configuration) {
 		omf := objectMeta(configuration.ObjectMeta)
 		nf(omf)
 		configuration.ObjectMeta = omf.Get()
@@ -74,7 +74,7 @@ func (f *knativeConfiguration) ObjectMeta(nf func(ObjectMeta)) *knativeConfigura
 }
 
 func (f *knativeConfiguration) PodTemplateSpec(nf func(PodTemplateSpec)) *knativeConfiguration {
-	return f.Mutate(func(configuration *knativeservingv1.Configuration) {
+	return f.mutation(func(configuration *knativeservingv1.Configuration) {
 		ptsf := podTemplateSpec(
 			// convert RevisionTemplateSpec into PodTemplateSpec
 			corev1.PodTemplateSpec{
@@ -97,7 +97,7 @@ func (f *knativeConfiguration) UserContainer(cb func(*corev1.Container)) *knativ
 }
 
 func (f *knativeConfiguration) StatusConditions(conditions ...*condition) *knativeConfiguration {
-	return f.Mutate(func(configuration *knativeservingv1.Configuration) {
+	return f.mutation(func(configuration *knativeservingv1.Configuration) {
 		c := make([]apis.Condition, len(conditions))
 		for i, cg := range conditions {
 			c[i] = cg.Get()
@@ -113,7 +113,7 @@ func (f *knativeConfiguration) StatusReady() *knativeConfiguration {
 }
 
 func (f *knativeConfiguration) StatusObservedGeneration(generation int64) *knativeConfiguration {
-	return f.Mutate(func(configuration *knativeservingv1.Configuration) {
+	return f.mutation(func(configuration *knativeservingv1.Configuration) {
 		configuration.Status.ObservedGeneration = generation
 	})
 }

--- a/pkg/controllers/testing/factories/knative_route.go
+++ b/pkg/controllers/testing/factories/knative_route.go
@@ -50,21 +50,21 @@ func (f *knativeRoute) Get() *knativeservingv1.Route {
 	return f.deepCopy().target
 }
 
-func (f *knativeRoute) Mutate(m func(*knativeservingv1.Route)) *knativeRoute {
+func (f *knativeRoute) mutation(m func(*knativeservingv1.Route)) *knativeRoute {
 	f = f.deepCopy()
 	m(f.target)
 	return f
 }
 
 func (f *knativeRoute) NamespaceName(namespace, name string) *knativeRoute {
-	return f.Mutate(func(route *knativeservingv1.Route) {
+	return f.mutation(func(route *knativeservingv1.Route) {
 		route.ObjectMeta.Namespace = namespace
 		route.ObjectMeta.Name = name
 	})
 }
 
 func (f *knativeRoute) ObjectMeta(nf func(ObjectMeta)) *knativeRoute {
-	return f.Mutate(func(route *knativeservingv1.Route) {
+	return f.mutation(func(route *knativeservingv1.Route) {
 		omf := objectMeta(route.ObjectMeta)
 		nf(omf)
 		route.ObjectMeta = omf.Get()
@@ -72,13 +72,13 @@ func (f *knativeRoute) ObjectMeta(nf func(ObjectMeta)) *knativeRoute {
 }
 
 func (f *knativeRoute) Traffic(traffic ...knativeservingv1.TrafficTarget) *knativeRoute {
-	return f.Mutate(func(route *knativeservingv1.Route) {
+	return f.mutation(func(route *knativeservingv1.Route) {
 		route.Spec.Traffic = traffic
 	})
 }
 
 func (f *knativeRoute) StatusConditions(conditions ...*condition) *knativeRoute {
-	return f.Mutate(func(route *knativeservingv1.Route) {
+	return f.mutation(func(route *knativeservingv1.Route) {
 		c := make([]apis.Condition, len(conditions))
 		for i, cg := range conditions {
 			c[i] = cg.Get()
@@ -94,13 +94,13 @@ func (f *knativeRoute) StatusReady() *knativeRoute {
 }
 
 func (f *knativeRoute) StatusObservedGeneration(generation int64) *knativeRoute {
-	return f.Mutate(func(route *knativeservingv1.Route) {
+	return f.mutation(func(route *knativeservingv1.Route) {
 		route.Status.ObservedGeneration = generation
 	})
 }
 
 func (f *knativeRoute) StatusAddressURL(url string) *knativeRoute {
-	return f.Mutate(func(route *knativeservingv1.Route) {
+	return f.mutation(func(route *knativeservingv1.Route) {
 		route.Status.Address = &apis.Addressable{
 			URL: url,
 		}
@@ -108,7 +108,7 @@ func (f *knativeRoute) StatusAddressURL(url string) *knativeRoute {
 }
 
 func (f *knativeRoute) StatusURL(url string) *knativeRoute {
-	return f.Mutate(func(route *knativeservingv1.Route) {
+	return f.mutation(func(route *knativeservingv1.Route) {
 		route.Status.URL = url
 	})
 }

--- a/pkg/controllers/testing/factories/knative_service.go
+++ b/pkg/controllers/testing/factories/knative_service.go
@@ -52,21 +52,21 @@ func (f *knativeService) Get() *knativeservingv1.Service {
 	return f.deepCopy().target
 }
 
-func (f *knativeService) Mutate(m func(*knativeservingv1.Service)) *knativeService {
+func (f *knativeService) mutation(m func(*knativeservingv1.Service)) *knativeService {
 	f = f.deepCopy()
 	m(f.target)
 	return f
 }
 
 func (f *knativeService) NamespaceName(namespace, name string) *knativeService {
-	return f.Mutate(func(service *knativeservingv1.Service) {
+	return f.mutation(func(service *knativeservingv1.Service) {
 		service.ObjectMeta.Namespace = namespace
 		service.ObjectMeta.Name = name
 	})
 }
 
 func (f *knativeService) ObjectMeta(nf func(ObjectMeta)) *knativeService {
-	return f.Mutate(func(service *knativeservingv1.Service) {
+	return f.mutation(func(service *knativeservingv1.Service) {
 		omf := objectMeta(service.ObjectMeta)
 		nf(omf)
 		service.ObjectMeta = omf.Get()
@@ -74,7 +74,7 @@ func (f *knativeService) ObjectMeta(nf func(ObjectMeta)) *knativeService {
 }
 
 func (f *knativeService) PodTemplateSpec(nf func(PodTemplateSpec)) *knativeService {
-	return f.Mutate(func(service *knativeservingv1.Service) {
+	return f.mutation(func(service *knativeservingv1.Service) {
 		ptsf := podTemplateSpec(
 			// convert RevisionTemplateSpec into PodTemplateSpec
 			corev1.PodTemplateSpec{
@@ -97,7 +97,7 @@ func (f *knativeService) UserContainer(cb func(*corev1.Container)) *knativeServi
 }
 
 func (f *knativeService) StatusConditions(conditions ...*condition) *knativeService {
-	return f.Mutate(func(service *knativeservingv1.Service) {
+	return f.mutation(func(service *knativeservingv1.Service) {
 		c := make([]apis.Condition, len(conditions))
 		for i, cg := range conditions {
 			c[i] = cg.Get()
@@ -113,7 +113,7 @@ func (f *knativeService) StatusReady() *knativeService {
 }
 
 func (f *knativeService) StatusObservedGeneration(generation int64) *knativeService {
-	return f.Mutate(func(service *knativeservingv1.Service) {
+	return f.mutation(func(service *knativeservingv1.Service) {
 		service.Status.ObservedGeneration = generation
 	})
 }

--- a/pkg/controllers/testing/factories/kpack_clusterbuilder.go
+++ b/pkg/controllers/testing/factories/kpack_clusterbuilder.go
@@ -50,21 +50,21 @@ func (f *kpackClusterBuilder) Get() *kpackbuildv1alpha1.ClusterBuilder {
 	return f.deepCopy().target
 }
 
-func (f *kpackClusterBuilder) Mutate(m func(*kpackbuildv1alpha1.ClusterBuilder)) *kpackClusterBuilder {
+func (f *kpackClusterBuilder) mutation(m func(*kpackbuildv1alpha1.ClusterBuilder)) *kpackClusterBuilder {
 	f = f.deepCopy()
 	m(f.target)
 	return f
 }
 
 func (f *kpackClusterBuilder) NamespaceName(namespace, name string) *kpackClusterBuilder {
-	return f.Mutate(func(cb *kpackbuildv1alpha1.ClusterBuilder) {
+	return f.mutation(func(cb *kpackbuildv1alpha1.ClusterBuilder) {
 		cb.ObjectMeta.Namespace = namespace
 		cb.ObjectMeta.Name = name
 	})
 }
 
 func (f *kpackClusterBuilder) ObjectMeta(nf func(ObjectMeta)) *kpackClusterBuilder {
-	return f.Mutate(func(cb *kpackbuildv1alpha1.ClusterBuilder) {
+	return f.mutation(func(cb *kpackbuildv1alpha1.ClusterBuilder) {
 		omf := objectMeta(cb.ObjectMeta)
 		nf(omf)
 		cb.ObjectMeta = omf.Get()
@@ -72,13 +72,13 @@ func (f *kpackClusterBuilder) ObjectMeta(nf func(ObjectMeta)) *kpackClusterBuild
 }
 
 func (f *kpackClusterBuilder) Image(format string, a ...interface{}) *kpackClusterBuilder {
-	return f.Mutate(func(cb *kpackbuildv1alpha1.ClusterBuilder) {
+	return f.mutation(func(cb *kpackbuildv1alpha1.ClusterBuilder) {
 		cb.Spec.Image = fmt.Sprintf(format, a...)
 	})
 }
 
 func (f *kpackClusterBuilder) StatusConditions(conditions ...*condition) *kpackClusterBuilder {
-	return f.Mutate(func(cb *kpackbuildv1alpha1.ClusterBuilder) {
+	return f.mutation(func(cb *kpackbuildv1alpha1.ClusterBuilder) {
 		c := make([]apis.Condition, len(conditions))
 		for i, cg := range conditions {
 			c[i] = cg.Get()
@@ -94,13 +94,13 @@ func (f *kpackClusterBuilder) StatusReady() *kpackClusterBuilder {
 }
 
 func (f *kpackClusterBuilder) StatusObservedGeneration(generation int64) *kpackClusterBuilder {
-	return f.Mutate(func(cb *kpackbuildv1alpha1.ClusterBuilder) {
+	return f.mutation(func(cb *kpackbuildv1alpha1.ClusterBuilder) {
 		cb.Status.ObservedGeneration = generation
 	})
 }
 
 func (f *kpackClusterBuilder) StatusLatestImage(format string, a ...interface{}) *kpackClusterBuilder {
-	return f.Mutate(func(cb *kpackbuildv1alpha1.ClusterBuilder) {
+	return f.mutation(func(cb *kpackbuildv1alpha1.ClusterBuilder) {
 		cb.Status.LatestImage = fmt.Sprintf(format, a...)
 	})
 }

--- a/pkg/controllers/testing/factories/kpack_image.go
+++ b/pkg/controllers/testing/factories/kpack_image.go
@@ -54,21 +54,21 @@ func (f *kpackImage) Get() *kpackbuildv1alpha1.Image {
 	return f.deepCopy().target
 }
 
-func (f *kpackImage) Mutate(m func(*kpackbuildv1alpha1.Image)) *kpackImage {
+func (f *kpackImage) mutation(m func(*kpackbuildv1alpha1.Image)) *kpackImage {
 	f = f.deepCopy()
 	m(f.target)
 	return f
 }
 
 func (f *kpackImage) NamespaceName(namespace, name string) *kpackImage {
-	return f.Mutate(func(image *kpackbuildv1alpha1.Image) {
+	return f.mutation(func(image *kpackbuildv1alpha1.Image) {
 		image.ObjectMeta.Namespace = namespace
 		image.ObjectMeta.Name = name
 	})
 }
 
 func (f *kpackImage) ObjectMeta(nf func(ObjectMeta)) *kpackImage {
-	return f.Mutate(func(image *kpackbuildv1alpha1.Image) {
+	return f.mutation(func(image *kpackbuildv1alpha1.Image) {
 		omf := objectMeta(image.ObjectMeta)
 		nf(omf)
 		image.ObjectMeta = omf.Get()
@@ -76,7 +76,7 @@ func (f *kpackImage) ObjectMeta(nf func(ObjectMeta)) *kpackImage {
 }
 
 func (f *kpackImage) ApplicationBuilder() *kpackImage {
-	return f.Mutate(func(image *kpackbuildv1alpha1.Image) {
+	return f.mutation(func(image *kpackbuildv1alpha1.Image) {
 		image.Spec.Builder = kpackbuildv1alpha1.ImageBuilder{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "ClusterBuilder",
@@ -88,7 +88,7 @@ func (f *kpackImage) ApplicationBuilder() *kpackImage {
 }
 
 func (f *kpackImage) FunctionBuilder(artifact, handler, invoker string) *kpackImage {
-	return f.Mutate(func(image *kpackbuildv1alpha1.Image) {
+	return f.mutation(func(image *kpackbuildv1alpha1.Image) {
 		image.Spec.Builder = kpackbuildv1alpha1.ImageBuilder{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "ClusterBuilder",
@@ -126,13 +126,13 @@ func (f *kpackImage) FunctionBuilder(artifact, handler, invoker string) *kpackIm
 }
 
 func (f *kpackImage) Tag(format string, a ...interface{}) *kpackImage {
-	return f.Mutate(func(image *kpackbuildv1alpha1.Image) {
+	return f.mutation(func(image *kpackbuildv1alpha1.Image) {
 		image.Spec.Tag = fmt.Sprintf(format, a...)
 	})
 }
 
 func (f *kpackImage) SourceGit(url string, revision string) *kpackImage {
-	return f.Mutate(func(image *kpackbuildv1alpha1.Image) {
+	return f.mutation(func(image *kpackbuildv1alpha1.Image) {
 		image.Spec.Source = kpackbuildv1alpha1.SourceConfig{
 			Git: &kpackbuildv1alpha1.Git{
 				URL:      url,
@@ -144,13 +144,13 @@ func (f *kpackImage) SourceGit(url string, revision string) *kpackImage {
 }
 
 func (f *kpackImage) SourceSubPath(subpath string) *kpackImage {
-	return f.Mutate(func(image *kpackbuildv1alpha1.Image) {
+	return f.mutation(func(image *kpackbuildv1alpha1.Image) {
 		image.Spec.Source.SubPath = subpath
 	})
 }
 
 func (f *kpackImage) BuildCache(quantity string) *kpackImage {
-	return f.Mutate(func(image *kpackbuildv1alpha1.Image) {
+	return f.mutation(func(image *kpackbuildv1alpha1.Image) {
 		size, err := resource.ParseQuantity(quantity)
 		if err != nil {
 			panic(err)
@@ -160,7 +160,7 @@ func (f *kpackImage) BuildCache(quantity string) *kpackImage {
 }
 
 func (f *kpackImage) StatusConditions(conditions ...*condition) *kpackImage {
-	return f.Mutate(func(image *kpackbuildv1alpha1.Image) {
+	return f.mutation(func(image *kpackbuildv1alpha1.Image) {
 		c := make([]apis.Condition, len(conditions))
 		for i, cg := range conditions {
 			c[i] = cg.Get()
@@ -176,19 +176,19 @@ func (f *kpackImage) StatusReady() *kpackImage {
 }
 
 func (f *kpackImage) StatusObservedGeneration(generation int64) *kpackImage {
-	return f.Mutate(func(image *kpackbuildv1alpha1.Image) {
+	return f.mutation(func(image *kpackbuildv1alpha1.Image) {
 		image.Status.ObservedGeneration = generation
 	})
 }
 
 func (f *kpackImage) StatusLatestImage(format string, a ...interface{}) *kpackImage {
-	return f.Mutate(func(image *kpackbuildv1alpha1.Image) {
+	return f.mutation(func(image *kpackbuildv1alpha1.Image) {
 		image.Status.LatestImage = fmt.Sprintf(format, a...)
 	})
 }
 
 func (f *kpackImage) StatusBuildCacheName(format string, a ...interface{}) *kpackImage {
-	return f.Mutate(func(image *kpackbuildv1alpha1.Image) {
+	return f.mutation(func(image *kpackbuildv1alpha1.Image) {
 		image.Status.BuildCacheName = fmt.Sprintf(format, a...)
 	})
 }

--- a/pkg/controllers/testing/factories/objectmeta.go
+++ b/pkg/controllers/testing/factories/objectmeta.go
@@ -25,7 +25,7 @@ import (
 )
 
 type ObjectMeta interface {
-	Mutate(m func(*metav1.ObjectMeta)) ObjectMeta
+	mutate(m func(*metav1.ObjectMeta)) ObjectMeta
 	Get() metav1.ObjectMeta
 
 	Namespace(namespace string) ObjectMeta
@@ -53,31 +53,31 @@ func (f *objectMetaImpl) Get() metav1.ObjectMeta {
 	return *(f.target.DeepCopy())
 }
 
-func (f *objectMetaImpl) Mutate(m func(*metav1.ObjectMeta)) ObjectMeta {
+func (f *objectMetaImpl) mutate(m func(*metav1.ObjectMeta)) ObjectMeta {
 	m(f.target)
 	return f
 }
 
 func (f *objectMetaImpl) Namespace(namespace string) ObjectMeta {
-	return f.Mutate(func(om *metav1.ObjectMeta) {
+	return f.mutate(func(om *metav1.ObjectMeta) {
 		om.Namespace = namespace
 	})
 }
 
 func (f *objectMetaImpl) Name(format string, a ...interface{}) ObjectMeta {
-	return f.Mutate(func(om *metav1.ObjectMeta) {
+	return f.mutate(func(om *metav1.ObjectMeta) {
 		om.Name = fmt.Sprintf(format, a...)
 	})
 }
 
 func (f *objectMetaImpl) GenerateName(format string, a ...interface{}) ObjectMeta {
-	return f.Mutate(func(om *metav1.ObjectMeta) {
+	return f.mutate(func(om *metav1.ObjectMeta) {
 		om.GenerateName = fmt.Sprintf(format, a...)
 	})
 }
 
 func (f *objectMetaImpl) AddLabel(key, value string) ObjectMeta {
-	return f.Mutate(func(om *metav1.ObjectMeta) {
+	return f.mutate(func(om *metav1.ObjectMeta) {
 		if om.Labels == nil {
 			om.Labels = map[string]string{}
 		}
@@ -86,7 +86,7 @@ func (f *objectMetaImpl) AddLabel(key, value string) ObjectMeta {
 }
 
 func (f *objectMetaImpl) AddAnnotation(key, value string) ObjectMeta {
-	return f.Mutate(func(om *metav1.ObjectMeta) {
+	return f.mutate(func(om *metav1.ObjectMeta) {
 		if om.Annotations == nil {
 			om.Annotations = map[string]string{}
 		}
@@ -95,13 +95,13 @@ func (f *objectMetaImpl) AddAnnotation(key, value string) ObjectMeta {
 }
 
 func (f *objectMetaImpl) Generation(generation int64) ObjectMeta {
-	return f.Mutate(func(om *metav1.ObjectMeta) {
+	return f.mutate(func(om *metav1.ObjectMeta) {
 		om.Generation = generation
 	})
 }
 
 func (f *objectMetaImpl) ControlledBy(owner metav1.Object, scheme *runtime.Scheme) ObjectMeta {
-	return f.Mutate(func(om *metav1.ObjectMeta) {
+	return f.mutate(func(om *metav1.ObjectMeta) {
 		err := ctrl.SetControllerReference(owner, om, scheme)
 		if err != nil {
 			panic(err)
@@ -110,14 +110,14 @@ func (f *objectMetaImpl) ControlledBy(owner metav1.Object, scheme *runtime.Schem
 }
 
 func (f *objectMetaImpl) Created(sec int64) ObjectMeta {
-	return f.Mutate(func(om *metav1.ObjectMeta) {
+	return f.mutate(func(om *metav1.ObjectMeta) {
 		timestamp := metav1.Unix(sec, 0)
 		om.CreationTimestamp = timestamp
 	})
 }
 
 func (f *objectMetaImpl) Deleted(sec int64) ObjectMeta {
-	return f.Mutate(func(om *metav1.ObjectMeta) {
+	return f.mutate(func(om *metav1.ObjectMeta) {
 		timestamp := metav1.Unix(sec, 0)
 		om.DeletionTimestamp = &timestamp
 	})

--- a/pkg/controllers/testing/factories/podtemplatespec.go
+++ b/pkg/controllers/testing/factories/podtemplatespec.go
@@ -21,7 +21,7 @@ import (
 )
 
 type PodTemplateSpec interface {
-	Mutate(m func(*corev1.PodTemplateSpec)) PodTemplateSpec
+	mutate(m func(*corev1.PodTemplateSpec)) PodTemplateSpec
 	Get() corev1.PodTemplateSpec
 
 	AddLabel(key, value string) PodTemplateSpec
@@ -43,13 +43,13 @@ func (f *podTemplateSpecImpl) Get() corev1.PodTemplateSpec {
 	return *(f.target.DeepCopy())
 }
 
-func (f *podTemplateSpecImpl) Mutate(m func(*corev1.PodTemplateSpec)) PodTemplateSpec {
+func (f *podTemplateSpecImpl) mutate(m func(*corev1.PodTemplateSpec)) PodTemplateSpec {
 	m(f.target)
 	return f
 }
 
 func (f *podTemplateSpecImpl) AddLabel(key, value string) PodTemplateSpec {
-	return f.Mutate(func(pts *corev1.PodTemplateSpec) {
+	return f.mutate(func(pts *corev1.PodTemplateSpec) {
 		if pts.Labels == nil {
 			pts.Labels = map[string]string{}
 		}
@@ -58,7 +58,7 @@ func (f *podTemplateSpecImpl) AddLabel(key, value string) PodTemplateSpec {
 }
 
 func (f *podTemplateSpecImpl) AddAnnotation(key, value string) PodTemplateSpec {
-	return f.Mutate(func(pts *corev1.PodTemplateSpec) {
+	return f.mutate(func(pts *corev1.PodTemplateSpec) {
 		if pts.Annotations == nil {
 			pts.Annotations = map[string]string{}
 		}
@@ -67,7 +67,7 @@ func (f *podTemplateSpecImpl) AddAnnotation(key, value string) PodTemplateSpec {
 }
 
 func (f *podTemplateSpecImpl) ContainerNamed(name string, cb func(*corev1.Container)) PodTemplateSpec {
-	return f.Mutate(func(pts *corev1.PodTemplateSpec) {
+	return f.mutate(func(pts *corev1.PodTemplateSpec) {
 		found := false
 		// check for existing container
 		for i, container := range pts.Spec.Containers {

--- a/pkg/controllers/testing/factories/processor.go
+++ b/pkg/controllers/testing/factories/processor.go
@@ -54,21 +54,21 @@ func (f *processor) Get() *streamingv1alpha1.Processor {
 	return f.deepCopy().target
 }
 
-func (f *processor) Mutate(m func(*streamingv1alpha1.Processor)) *processor {
+func (f *processor) mutation(m func(*streamingv1alpha1.Processor)) *processor {
 	f = f.deepCopy()
 	m(f.target)
 	return f
 }
 
 func (f *processor) NamespaceName(namespace, name string) *processor {
-	return f.Mutate(func(p *streamingv1alpha1.Processor) {
+	return f.mutation(func(p *streamingv1alpha1.Processor) {
 		p.ObjectMeta.Namespace = namespace
 		p.ObjectMeta.Name = name
 	})
 }
 
 func (f *processor) ObjectMeta(nf func(ObjectMeta)) *processor {
-	return f.Mutate(func(s *streamingv1alpha1.Processor) {
+	return f.mutation(func(s *streamingv1alpha1.Processor) {
 		omf := objectMeta(s.ObjectMeta)
 		nf(omf)
 		s.ObjectMeta = omf.Get()
@@ -76,7 +76,7 @@ func (f *processor) ObjectMeta(nf func(ObjectMeta)) *processor {
 }
 
 func (f *processor) PodTemplateSpec(nf func(PodTemplateSpec)) *processor {
-	return f.Mutate(func(processor *streamingv1alpha1.Processor) {
+	return f.mutation(func(processor *streamingv1alpha1.Processor) {
 		var ptsf *podTemplateSpecImpl
 		if processor.Spec.Template != nil {
 			ptsf = podTemplateSpec(*processor.Spec.Template)
@@ -90,7 +90,7 @@ func (f *processor) PodTemplateSpec(nf func(PodTemplateSpec)) *processor {
 }
 
 func (f *processor) StatusConditions(conditions ...*condition) *processor {
-	return f.Mutate(func(processor *streamingv1alpha1.Processor) {
+	return f.mutation(func(processor *streamingv1alpha1.Processor) {
 		c := make([]apis.Condition, len(conditions))
 		for i, cg := range conditions {
 			dc := cg.Get()
@@ -106,13 +106,13 @@ func (f *processor) StatusConditions(conditions ...*condition) *processor {
 }
 
 func (f *processor) StatusLatestImage(image string) *processor {
-	return f.Mutate(func(proc *streamingv1alpha1.Processor) {
+	return f.mutation(func(proc *streamingv1alpha1.Processor) {
 		proc.Status.LatestImage = image
 	})
 }
 
 func (f *processor) StatusDeploymentRef(deploymentName string) *processor {
-	return f.Mutate(func(proc *streamingv1alpha1.Processor) {
+	return f.mutation(func(proc *streamingv1alpha1.Processor) {
 		proc.Status.DeploymentRef = &refs.TypedLocalObjectReference{
 			APIGroup: rtesting.StringPtr("apps"),
 			Kind:     "Deployment",
@@ -122,7 +122,7 @@ func (f *processor) StatusDeploymentRef(deploymentName string) *processor {
 }
 
 func (f *processor) SpecBuildFunctionRef(functionName string) *processor {
-	return f.Mutate(func(proc *streamingv1alpha1.Processor) {
+	return f.mutation(func(proc *streamingv1alpha1.Processor) {
 		proc.Spec.Build = &streamingv1alpha1.Build{
 			FunctionRef: functionName,
 		}
@@ -130,7 +130,7 @@ func (f *processor) SpecBuildFunctionRef(functionName string) *processor {
 }
 
 func (f *processor) SpecBuildContainerRef(containerName string) *processor {
-	return f.Mutate(func(proc *streamingv1alpha1.Processor) {
+	return f.mutation(func(proc *streamingv1alpha1.Processor) {
 		proc.Spec.Build = &streamingv1alpha1.Build{
 			ContainerRef: containerName,
 		}
@@ -138,7 +138,7 @@ func (f *processor) SpecBuildContainerRef(containerName string) *processor {
 }
 
 func (f *processor) StatusScaledObjectRef(deploymentName string) *processor {
-	return f.Mutate(func(proc *streamingv1alpha1.Processor) {
+	return f.mutation(func(proc *streamingv1alpha1.Processor) {
 		proc.Status.ScaledObjectRef = &refs.TypedLocalObjectReference{
 			APIGroup: rtesting.StringPtr("keda.k8s.io"),
 			Kind:     "ScaledObject",

--- a/pkg/controllers/testing/factories/secret.go
+++ b/pkg/controllers/testing/factories/secret.go
@@ -50,21 +50,21 @@ func (f *secret) Get() *corev1.Secret {
 	return f.deepCopy().target
 }
 
-func (f *secret) Mutate(m func(*corev1.Secret)) *secret {
+func (f *secret) mutation(m func(*corev1.Secret)) *secret {
 	f = f.deepCopy()
 	m(f.target)
 	return f
 }
 
 func (f *secret) NamespaceName(namespace, name string) *secret {
-	return f.Mutate(func(s *corev1.Secret) {
+	return f.mutation(func(s *corev1.Secret) {
 		s.ObjectMeta.Namespace = namespace
 		s.ObjectMeta.Name = name
 	})
 }
 
 func (f *secret) ObjectMeta(nf func(ObjectMeta)) *secret {
-	return f.Mutate(func(s *corev1.Secret) {
+	return f.mutation(func(s *corev1.Secret) {
 		omf := objectMeta(s.ObjectMeta)
 		nf(omf)
 		s.ObjectMeta = omf.Get()
@@ -72,13 +72,13 @@ func (f *secret) ObjectMeta(nf func(ObjectMeta)) *secret {
 }
 
 func (f *secret) Type(t corev1.SecretType) *secret {
-	return f.Mutate(func(s *corev1.Secret) {
+	return f.mutation(func(s *corev1.Secret) {
 		s.Type = t
 	})
 }
 
 func (f *secret) AddData(key, value string) *secret {
-	return f.Mutate(func(s *corev1.Secret) {
+	return f.mutation(func(s *corev1.Secret) {
 		if s.Data == nil {
 			s.Data = map[string][]byte{}
 		}

--- a/pkg/controllers/testing/factories/service.go
+++ b/pkg/controllers/testing/factories/service.go
@@ -49,21 +49,21 @@ func (f *service) Get() *corev1.Service {
 	return f.deepCopy().target
 }
 
-func (f *service) Mutate(m func(*corev1.Service)) *service {
+func (f *service) mutation(m func(*corev1.Service)) *service {
 	f = f.deepCopy()
 	m(f.target)
 	return f
 }
 
 func (f *service) NamespaceName(namespace, name string) *service {
-	return f.Mutate(func(sa *corev1.Service) {
+	return f.mutation(func(sa *corev1.Service) {
 		sa.ObjectMeta.Namespace = namespace
 		sa.ObjectMeta.Name = name
 	})
 }
 
 func (f *service) ObjectMeta(nf func(ObjectMeta)) *service {
-	return f.Mutate(func(sa *corev1.Service) {
+	return f.mutation(func(sa *corev1.Service) {
 		omf := objectMeta(sa.ObjectMeta)
 		nf(omf)
 		sa.ObjectMeta = omf.Get()
@@ -71,7 +71,7 @@ func (f *service) ObjectMeta(nf func(ObjectMeta)) *service {
 }
 
 func (f *service) AddSelectorLabel(key, value string) *service {
-	return f.Mutate(func(service *corev1.Service) {
+	return f.mutation(func(service *corev1.Service) {
 		if service.Spec.Selector == nil {
 			service.Spec.Selector = map[string]string{}
 		}
@@ -80,7 +80,7 @@ func (f *service) AddSelectorLabel(key, value string) *service {
 }
 
 func (f *service) Ports(ports ...corev1.ServicePort) *service {
-	return f.Mutate(func(service *corev1.Service) {
+	return f.mutation(func(service *corev1.Service) {
 		service.Spec.Ports = ports
 	})
 }

--- a/pkg/controllers/testing/factories/serviceaccount.go
+++ b/pkg/controllers/testing/factories/serviceaccount.go
@@ -49,21 +49,21 @@ func (f *serviceAccount) Get() *corev1.ServiceAccount {
 	return f.deepCopy().target
 }
 
-func (f *serviceAccount) Mutate(m func(*corev1.ServiceAccount)) *serviceAccount {
+func (f *serviceAccount) mutation(m func(*corev1.ServiceAccount)) *serviceAccount {
 	f = f.deepCopy()
 	m(f.target)
 	return f
 }
 
 func (f *serviceAccount) NamespaceName(namespace, name string) *serviceAccount {
-	return f.Mutate(func(sa *corev1.ServiceAccount) {
+	return f.mutation(func(sa *corev1.ServiceAccount) {
 		sa.ObjectMeta.Namespace = namespace
 		sa.ObjectMeta.Name = name
 	})
 }
 
 func (f *serviceAccount) ObjectMeta(nf func(ObjectMeta)) *serviceAccount {
-	return f.Mutate(func(sa *corev1.ServiceAccount) {
+	return f.mutation(func(sa *corev1.ServiceAccount) {
 		omf := objectMeta(sa.ObjectMeta)
 		nf(omf)
 		sa.ObjectMeta = omf.Get()
@@ -71,7 +71,7 @@ func (f *serviceAccount) ObjectMeta(nf func(ObjectMeta)) *serviceAccount {
 }
 
 func (f *serviceAccount) Secrets(secrets ...string) *serviceAccount {
-	return f.Mutate(func(sa *corev1.ServiceAccount) {
+	return f.mutation(func(sa *corev1.ServiceAccount) {
 		sa.Secrets = make([]corev1.ObjectReference, len(secrets))
 		for i, secret := range secrets {
 			sa.Secrets[i] = corev1.ObjectReference{Name: secret}


### PR DESCRIPTION
Mutate() is unexported. This will encourage suitable helper methods to be
written rather than testcases calling Mutate(), which is frowned upon.

Those occurrences which do not mutate the factory are named mutation(); those
few occurences which do mutate the factory (for good reason) are named
mutate().

If someone could kindly rewrite Kubernetes in Rust, immutability would be a
lot clearer.