### PR TITLE
Record events for mutations

### DIFF
--- a/cmd/managers/build/main.go
+++ b/cmd/managers/build/main.go
@@ -71,9 +71,10 @@ func main() {
 	}
 
 	if err = (&controllers.ApplicationReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("Application"),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Recorder: mgr.GetEventRecorderFor("Application"),
+		Log:      ctrl.Log.WithName("controllers").WithName("Application"),
+		Scheme:   mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Application")
 		os.Exit(1)
@@ -83,9 +84,10 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&controllers.ContainerReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("Container"),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Recorder: mgr.GetEventRecorderFor("Container"),
+		Log:      ctrl.Log.WithName("controllers").WithName("Container"),
+		Scheme:   mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Container")
 		os.Exit(1)
@@ -95,9 +97,10 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&controllers.FunctionReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("Function"),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Recorder: mgr.GetEventRecorderFor("Function"),
+		Log:      ctrl.Log.WithName("controllers").WithName("Function"),
+		Scheme:   mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Function")
 		os.Exit(1)
@@ -107,14 +110,16 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&controllers.CredentialReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("Credentials"),
+		Client:   mgr.GetClient(),
+		Recorder: mgr.GetEventRecorderFor("Credential"),
+		Log:      ctrl.Log.WithName("controllers").WithName("Credentials"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Credential")
 		os.Exit(1)
 	}
 	if err = (&controllers.ClusterBuilderReconciler{
 		Client:    mgr.GetClient(),
+		Recorder:  mgr.GetEventRecorderFor("ClusterBuilder"),
 		Log:       ctrl.Log.WithName("controllers").WithName("ClusterBuilders"),
 		Namespace: namespace,
 	}).SetupWithManager(mgr); err != nil {

--- a/cmd/managers/core/main.go
+++ b/cmd/managers/core/main.go
@@ -75,10 +75,11 @@ func main() {
 	}
 
 	if err = (&controllers.DeployerReconciler{
-		Client:  mgr.GetClient(),
-		Log:     ctrl.Log.WithName("controllers").WithName("Deployer"),
-		Scheme:  mgr.GetScheme(),
-		Tracker: tracker.New(syncPeriod, ctrl.Log.WithName("controllers").WithName("Deployer").WithName("tracker")),
+		Client:   mgr.GetClient(),
+		Recorder: mgr.GetEventRecorderFor("Deployer"),
+		Log:      ctrl.Log.WithName("controllers").WithName("Deployer"),
+		Scheme:   mgr.GetScheme(),
+		Tracker:  tracker.New(syncPeriod, ctrl.Log.WithName("controllers").WithName("Deployer").WithName("tracker")),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Deployer")
 		os.Exit(1)

--- a/cmd/managers/knative/main.go
+++ b/cmd/managers/knative/main.go
@@ -77,10 +77,11 @@ func main() {
 	}
 
 	if err = (&controllers.AdapterReconciler{
-		Client:  mgr.GetClient(),
-		Log:     ctrl.Log.WithName("controllers").WithName("Adapter"),
-		Scheme:  mgr.GetScheme(),
-		Tracker: tracker.New(syncPeriod, ctrl.Log.WithName("controllers").WithName("Adapter").WithName("tracker")),
+		Client:   mgr.GetClient(),
+		Recorder: mgr.GetEventRecorderFor("Adapter"),
+		Log:      ctrl.Log.WithName("controllers").WithName("Adapter"),
+		Scheme:   mgr.GetScheme(),
+		Tracker:  tracker.New(syncPeriod, ctrl.Log.WithName("controllers").WithName("Adapter").WithName("tracker")),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Adapter")
 		os.Exit(1)
@@ -90,10 +91,11 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&controllers.DeployerReconciler{
-		Client:  mgr.GetClient(),
-		Log:     ctrl.Log.WithName("controllers").WithName("Deployer"),
-		Scheme:  mgr.GetScheme(),
-		Tracker: tracker.New(syncPeriod, ctrl.Log.WithName("controllers").WithName("Deployer").WithName("tracker")),
+		Client:   mgr.GetClient(),
+		Recorder: mgr.GetEventRecorderFor("Deployer"),
+		Log:      ctrl.Log.WithName("controllers").WithName("Deployer"),
+		Scheme:   mgr.GetScheme(),
+		Tracker:  tracker.New(syncPeriod, ctrl.Log.WithName("controllers").WithName("Deployer").WithName("tracker")),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Deployer")
 		os.Exit(1)

--- a/cmd/managers/streaming/main.go
+++ b/cmd/managers/streaming/main.go
@@ -80,6 +80,7 @@ func main() {
 
 	if err = (&controllers.KafkaProviderReconciler{
 		Client:    mgr.GetClient(),
+		Recorder:  mgr.GetEventRecorderFor("KafkaProvider"),
 		Log:       ctrl.Log.WithName("controllers").WithName("KafkaProvider"),
 		Scheme:    mgr.GetScheme(),
 		Tracker:   tracker.New(syncPeriod, ctrl.Log.WithName("controllers").WithName("KafkaProvider").WithName("tracker")),
@@ -94,6 +95,7 @@ func main() {
 	}
 	if err = (&controllers.PulsarProviderReconciler{
 		Client:    mgr.GetClient(),
+		Recorder:  mgr.GetEventRecorderFor("PulsarProvider"),
 		Log:       ctrl.Log.WithName("controllers").WithName("PulsarProvider"),
 		Scheme:    mgr.GetScheme(),
 		Tracker:   tracker.New(syncPeriod, ctrl.Log.WithName("controllers").WithName("PulsarProvider").WithName("tracker")),
@@ -108,6 +110,7 @@ func main() {
 	}
 	if err = (&controllers.InMemoryProviderReconciler{
 		Client:    mgr.GetClient(),
+		Recorder:  mgr.GetEventRecorderFor("InMemoryProvider"),
 		Log:       ctrl.Log.WithName("controllers").WithName("InMemoryProvider"),
 		Scheme:    mgr.GetScheme(),
 		Tracker:   tracker.New(syncPeriod, ctrl.Log.WithName("controllers").WithName("InMemoryProvider").WithName("tracker")),
@@ -123,6 +126,7 @@ func main() {
 	streamControllerLogger := ctrl.Log.WithName("controllers").WithName("Stream")
 	if err = (&controllers.StreamReconciler{
 		Client:                  mgr.GetClient(),
+		Recorder:                mgr.GetEventRecorderFor("Stream"),
 		Log:                     streamControllerLogger,
 		Scheme:                  mgr.GetScheme(),
 		StreamProvisionerClient: controllers.NewStreamProvisionerClient(http.DefaultClient, streamControllerLogger),
@@ -136,6 +140,7 @@ func main() {
 	}
 	if err = (&controllers.ProcessorReconciler{
 		Client:    mgr.GetClient(),
+		Recorder:  mgr.GetEventRecorderFor("Processor"),
 		Log:       ctrl.Log.WithName("controllers").WithName("Processor"),
 		Scheme:    mgr.GetScheme(),
 		Tracker:   tracker.New(syncPeriod, ctrl.Log.WithName("controllers").WithName("Processor").WithName("tracker")),

--- a/config/build/rbac/role.yaml
+++ b/config/build/rbac/role.yaml
@@ -110,6 +110,18 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - get

--- a/config/core/rbac/role.yaml
+++ b/config/core/rbac/role.yaml
@@ -31,6 +31,18 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services
   verbs:
   - create

--- a/config/knative/rbac/role.yaml
+++ b/config/knative/rbac/role.yaml
@@ -17,6 +17,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - knative.projectriff.io
   resources:
   - adapters

--- a/config/riff-build.yaml
+++ b/config/riff-build.yaml
@@ -815,6 +815,18 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - get

--- a/config/riff-core.yaml
+++ b/config/riff-core.yaml
@@ -2855,6 +2855,18 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services
   verbs:
   - create

--- a/config/riff-knative.yaml
+++ b/config/riff-knative.yaml
@@ -2955,6 +2955,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - knative.projectriff.io
   resources:
   - adapters

--- a/config/riff-streaming.yaml
+++ b/config/riff-streaming.yaml
@@ -3442,6 +3442,18 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create

--- a/config/streaming/rbac/role.yaml
+++ b/config/streaming/rbac/role.yaml
@@ -47,6 +47,18 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create

--- a/pkg/controllers/build/clusterbuilder_controller.go
+++ b/pkg/controllers/build/clusterbuilder_controller.go
@@ -27,6 +27,7 @@ import (
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -43,12 +44,14 @@ const buildersConfigMap = "builders"
 // ClusterBuilderReconciler reconciles a ClusterBuilder object
 type ClusterBuilderReconciler struct {
 	client.Client
+	Recorder  record.EventRecorder
 	Log       logr.Logger
 	Namespace string
 }
 
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=build.pivotal.io,resources=clusterbuilders,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;update;patch;delete
 
 func (r *ClusterBuilderReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()

--- a/pkg/controllers/build/clusterbuilder_controller_test.go
+++ b/pkg/controllers/build/clusterbuilder_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -197,9 +198,10 @@ func TestClusterBuildersReconciler(t *testing.T) {
 		ShouldErr: true,
 	}}
 
-	table.Test(t, scheme, func(t *testing.T, row *rtesting.Testcase, client client.Client, tracker tracker.Tracker, log logr.Logger) reconcile.Reconciler {
+	table.Test(t, scheme, func(t *testing.T, row *rtesting.Testcase, client client.Client, tracker tracker.Tracker, recorder record.EventRecorder, log logr.Logger) reconcile.Reconciler {
 		return &build.ClusterBuilderReconciler{
 			Client:    client,
+			Recorder:  recorder,
 			Log:       log,
 			Namespace: testNamespace,
 		}

--- a/pkg/controllers/build/credential_controller.go
+++ b/pkg/controllers/build/credential_controller.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -43,12 +44,14 @@ import (
 // CredentialReconciler reconciles a Credential object
 type CredentialReconciler struct {
 	client.Client
-	Log logr.Logger
+	Recorder record.EventRecorder
+	Log      logr.Logger
 }
 
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=build.projectriff.io,resources=applications;functions,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;update;patch;delete
 
 func (r *CredentialReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()

--- a/pkg/controllers/build/credential_controller_test.go
+++ b/pkg/controllers/build/credential_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -318,10 +319,11 @@ func TestCredentialsReconciler(t *testing.T) {
 		},
 	}}
 
-	table.Test(t, scheme, func(t *testing.T, row *rtesting.Testcase, client client.Client, tracker tracker.Tracker, log logr.Logger) reconcile.Reconciler {
+	table.Test(t, scheme, func(t *testing.T, row *rtesting.Testcase, client client.Client, tracker tracker.Tracker, recorder record.EventRecorder, log logr.Logger) reconcile.Reconciler {
 		return &build.CredentialReconciler{
-			Client: client,
-			Log:    log,
+			Client:   client,
+			Recorder: recorder,
+			Log:      log,
 		}
 	})
 }

--- a/pkg/controllers/core/deployer_controller_test.go
+++ b/pkg/controllers/core/deployer_controller_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -181,6 +182,14 @@ func TestDeployerReconciler(t *testing.T) {
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
 			rtesting.NewTrackRequest(testApplication, deployerMinimal, scheme),
 		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "Created",
+				`Created Deployment "%s-deployer-001"`, testName),
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "Created",
+				`Created Service "%s"`, testName),
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
 		ExpectCreates: []rtesting.Factory{
 			deploymentCreate,
 			serviceCreate,
@@ -205,6 +214,10 @@ func TestDeployerReconciler(t *testing.T) {
 			deployerMinimal.
 				ApplicationRef(testApplication.Get().GetName()),
 			testSettings,
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
 		},
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
@@ -246,6 +259,14 @@ func TestDeployerReconciler(t *testing.T) {
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
 			rtesting.NewTrackRequest(testFunction, deployerMinimal, scheme),
 		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "Created",
+				`Created Deployment "%s-deployer-001"`, testName),
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "Created",
+				`Created Service "%s"`, testName),
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
 		ExpectCreates: []rtesting.Factory{
 			deploymentCreate,
 			serviceCreate,
@@ -270,6 +291,10 @@ func TestDeployerReconciler(t *testing.T) {
 			deployerMinimal.
 				FunctionRef(testFunction.Get().GetName()),
 			testSettings,
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
 		},
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
@@ -311,6 +336,14 @@ func TestDeployerReconciler(t *testing.T) {
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
 			rtesting.NewTrackRequest(testContainer, deployerMinimal, scheme),
 		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "Created",
+				`Created Deployment "%s-deployer-001"`, testName),
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "Created",
+				`Created Service "%s"`, testName),
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
 		ExpectCreates: []rtesting.Factory{
 			deploymentCreate,
 			serviceCreate,
@@ -339,6 +372,10 @@ func TestDeployerReconciler(t *testing.T) {
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
 			rtesting.NewTrackRequest(testContainer, deployerMinimal, scheme),
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
 		},
 		ExpectStatusUpdates: []rtesting.Factory{
 			deployerMinimal.
@@ -374,6 +411,14 @@ func TestDeployerReconciler(t *testing.T) {
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
 		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "Created",
+				`Created Deployment "%s-deployer-001"`, testName),
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "Created",
+				`Created Service "%s"`, testName),
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
 		ExpectCreates: []rtesting.Factory{
 			deploymentCreate,
 			serviceCreate,
@@ -406,6 +451,12 @@ func TestDeployerReconciler(t *testing.T) {
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
 		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeWarning, "CreationFailed",
+				`Failed to create Deployment "": inducing failure for create Deployment`),
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
 		ExpectCreates: []rtesting.Factory{
 			deploymentCreate,
 		},
@@ -432,6 +483,14 @@ func TestDeployerReconciler(t *testing.T) {
 		ShouldErr: true,
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "Created",
+				`Created Deployment "%s-deployer-001"`, testName),
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeWarning, "CreationFailed",
+				`Failed to create Service "%s": inducing failure for create Service`, testName),
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
 		},
 		ExpectCreates: []rtesting.Factory{
 			deploymentCreate,
@@ -462,6 +521,14 @@ func TestDeployerReconciler(t *testing.T) {
 		},
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "Created",
+				`Created Deployment "%s-deployer-001"`, testName),
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeWarning, "CreationFailed",
+				`Failed to create Service "%s":  "%s" already exists`, testName, testName),
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
 		},
 		ExpectCreates: []rtesting.Factory{
 			deploymentCreate,
@@ -504,6 +571,10 @@ func TestDeployerReconciler(t *testing.T) {
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
 		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "Updated",
+				`Updated Deployment "%s"`, deploymentGiven.Get().GetName()),
+		},
 		ExpectUpdates: []rtesting.Factory{
 			deploymentGiven,
 		},
@@ -537,6 +608,10 @@ func TestDeployerReconciler(t *testing.T) {
 		ShouldErr: true,
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeWarning, "UpdateFailed",
+				`Failed to update Deployment "%s": inducing failure for update Deployment`, deploymentGiven.Get().GetName()),
 		},
 		ExpectUpdates: []rtesting.Factory{
 			deploymentGiven,
@@ -597,6 +672,10 @@ func TestDeployerReconciler(t *testing.T) {
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
 		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "Updated",
+				`Updated Service "%s"`, serviceGiven.Get().GetName()),
+		},
 		ExpectUpdates: []rtesting.Factory{
 			serviceGiven,
 		},
@@ -628,6 +707,10 @@ func TestDeployerReconciler(t *testing.T) {
 		ShouldErr: true,
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeWarning, "UpdateFailed",
+				`Failed to update Service "%s": inducing failure for update Service`, serviceGiven.Get().GetName()),
 		},
 		ExpectUpdates: []rtesting.Factory{
 			serviceGiven,
@@ -684,6 +767,14 @@ func TestDeployerReconciler(t *testing.T) {
 			serviceGiven,
 			testSettings,
 		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "Deleted",
+				`Deleted Deployment "%s"`, "extra-deployment-1"),
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "Deleted",
+				`Deleted Deployment "%s"`, "extra-deployment-2"),
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "Created",
+				`Created Deployment "%s-deployer-001"`, testName),
+		},
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
 		},
@@ -721,6 +812,10 @@ func TestDeployerReconciler(t *testing.T) {
 			testSettings,
 		},
 		ShouldErr: true,
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeWarning, "DeleteFailed",
+				`Failed to delete Deployment "%s": inducing failure for delete Deployment`, "extra-deployment-1"),
+		},
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
 		},
@@ -749,6 +844,14 @@ func TestDeployerReconciler(t *testing.T) {
 			serviceGiven.
 				NamespaceName(testNamespace, "extra-service-2"),
 			testSettings,
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "Deleted",
+				`Deleted Service "%s"`, "extra-service-1"),
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "Deleted",
+				`Deleted Service "%s"`, "extra-service-2"),
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "Created",
+				`Created Service "%s"`, testName),
 		},
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
@@ -787,6 +890,10 @@ func TestDeployerReconciler(t *testing.T) {
 			testSettings,
 		},
 		ShouldErr: true,
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeWarning, "DeleteFailed",
+				`Failed to delete Service "%s": inducing failure for delete Service`, "extra-service-1"),
+		},
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
 		},
@@ -806,6 +913,12 @@ func TestDeployerReconciler(t *testing.T) {
 		},
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "Created",
+				`Created Ingress "%s-deployer-001"`, testName),
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
 		},
 		ExpectCreates: []rtesting.Factory{
 			ingressCreate,
@@ -843,6 +956,12 @@ func TestDeployerReconciler(t *testing.T) {
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
 		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeWarning, "CreationFailed",
+				`Failed to create Ingress "": inducing failure for create Ingress`),
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
 		ExpectCreates: []rtesting.Factory{
 			ingressCreate,
 		},
@@ -870,6 +989,12 @@ func TestDeployerReconciler(t *testing.T) {
 			ingressGiven,
 			testSettings.
 				AddData("defaultDomain", "not.example.com"),
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "Deleted",
+				`Deleted Ingress "%s"`, ingressGiven.Get().GetName()),
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
 		},
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
@@ -907,6 +1032,12 @@ func TestDeployerReconciler(t *testing.T) {
 				AddData("defaultDomain", "not.example.com"),
 		},
 		ShouldErr: true,
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeWarning, "DeleteFailed",
+				`Failed to delete Ingress "%s": inducing failure for delete Ingress`, ingressGiven.Get().GetName()),
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
 		},
@@ -940,6 +1071,12 @@ func TestDeployerReconciler(t *testing.T) {
 		},
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "Updated",
+				`Updated Ingress "%s"`, ingressGiven.Get().GetName()),
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
 		},
 		ExpectUpdates: []rtesting.Factory{
 			ingressGiven.
@@ -980,6 +1117,12 @@ func TestDeployerReconciler(t *testing.T) {
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
 		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeWarning, "UpdateFailed",
+				`Failed to update Ingress "%s": inducing failure for update Ingress`, ingressGiven.Get().GetName()),
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
 		ExpectUpdates: []rtesting.Factory{
 			ingressGiven.
 				HostToService(fmt.Sprintf("%s.%s.%s", testName, testNamespace, "not.example.com"), serviceGiven.Get().GetName()),
@@ -1010,6 +1153,16 @@ func TestDeployerReconciler(t *testing.T) {
 			ingressGiven.
 				NamespaceName(testNamespace, "extra-ingress-2"),
 			testSettings,
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "Deleted",
+				`Deleted Ingress "%s"`, "extra-ingress-1"),
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "Deleted",
+				`Deleted Ingress "%s"`, "extra-ingress-2"),
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "Created",
+				`Created Ingress "%s-deployer-001"`, testName),
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
 		},
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
@@ -1058,6 +1211,10 @@ func TestDeployerReconciler(t *testing.T) {
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
 		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
 		ExpectStatusUpdates: []rtesting.Factory{
 			deployerMinimal.
 				StatusConditions(
@@ -1089,6 +1246,12 @@ func TestDeployerReconciler(t *testing.T) {
 			testSettings,
 		},
 		ShouldErr: true,
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeWarning, "DeleteFailed",
+				`Failed to delete Ingress "%s": inducing failure for delete Ingress`, "extra-ingress-1"),
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
 		},
@@ -1137,6 +1300,14 @@ func TestDeployerReconciler(t *testing.T) {
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
 		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "Updated",
+				`Updated Deployment "%s"`, deploymentGiven.Get().GetName()),
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "Updated",
+				`Updated Service "%s"`, serviceGiven.Get().GetName()),
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "Updated",
+				`Updated Ingress "%s"`, ingressGiven.Get().GetName()),
+		},
 		ExpectUpdates: []rtesting.Factory{
 			deploymentGiven.
 				ObjectMeta(func(om factories.ObjectMeta) {
@@ -1169,6 +1340,10 @@ func TestDeployerReconciler(t *testing.T) {
 		},
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
 		},
 		ExpectStatusUpdates: []rtesting.Factory{
 			deployerMinimal.
@@ -1206,6 +1381,10 @@ func TestDeployerReconciler(t *testing.T) {
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
 		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
 		ExpectStatusUpdates: []rtesting.Factory{
 			deployerMinimal.
 				StatusConditions(
@@ -1237,6 +1416,10 @@ func TestDeployerReconciler(t *testing.T) {
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
 		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
 		ExpectStatusUpdates: []rtesting.Factory{
 			deployerMinimal.
 				StatusConditions(
@@ -1266,6 +1449,10 @@ func TestDeployerReconciler(t *testing.T) {
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
 		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeWarning, "StatusUpdateFailed",
+				`Failed to update status: inducing failure for update Deployer`),
+		},
 		ExpectStatusUpdates: []rtesting.Factory{
 			deployerMinimal.
 				StatusConditions(
@@ -1289,6 +1476,10 @@ func TestDeployerReconciler(t *testing.T) {
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testSettings, deployerMinimal, scheme),
 		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(deployerMinimal, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
 		ExpectStatusUpdates: []rtesting.Factory{
 			deployerMinimal.
 				StatusConditions(
@@ -1299,12 +1490,13 @@ func TestDeployerReconciler(t *testing.T) {
 		},
 	}}
 
-	table.Test(t, scheme, func(t *testing.T, row *rtesting.Testcase, client client.Client, tracker tracker.Tracker, log logr.Logger) reconcile.Reconciler {
+	table.Test(t, scheme, func(t *testing.T, row *rtesting.Testcase, client client.Client, tracker tracker.Tracker, recorder record.EventRecorder, log logr.Logger) reconcile.Reconciler {
 		return &core.DeployerReconciler{
-			Client:  client,
-			Scheme:  scheme,
-			Log:     log,
-			Tracker: tracker,
+			Client:   client,
+			Recorder: recorder,
+			Scheme:   scheme,
+			Log:      log,
+			Tracker:  tracker,
 		}
 	})
 }

--- a/pkg/controllers/knative/adapter_controller_test.go
+++ b/pkg/controllers/knative/adapter_controller_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -114,6 +115,10 @@ func TestAdapterReconciler(t *testing.T) {
 			rtesting.NewTrackRequest(testApplication, testAdapter, scheme),
 			rtesting.NewTrackRequest(testService, testAdapter, scheme),
 		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testAdapter, scheme, corev1.EventTypeWarning, "StatusUpdateFailed",
+				`Failed to update status: inducing failure for update Adapter`),
+		},
 		ExpectUpdates: []rtesting.Factory{
 			testService.
 				UserContainer(func(uc *corev1.Container) {
@@ -144,6 +149,10 @@ func TestAdapterReconciler(t *testing.T) {
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testApplication, testAdapter, scheme),
 			rtesting.NewTrackRequest(testService, testAdapter, scheme),
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testAdapter, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
 		},
 		ExpectUpdates: []rtesting.Factory{
 			testService.
@@ -185,6 +194,10 @@ func TestAdapterReconciler(t *testing.T) {
 		},
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testApplication, testAdapter, scheme),
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testAdapter, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
 		},
 		ExpectStatusUpdates: []rtesting.Factory{
 			testAdapter.
@@ -229,6 +242,10 @@ func TestAdapterReconciler(t *testing.T) {
 			rtesting.NewTrackRequest(testFunction, testAdapter, scheme),
 			rtesting.NewTrackRequest(testService, testAdapter, scheme),
 		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testAdapter, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
 		ExpectUpdates: []rtesting.Factory{
 			testService.
 				UserContainer(func(uc *corev1.Container) {
@@ -269,6 +286,10 @@ func TestAdapterReconciler(t *testing.T) {
 		},
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testFunction, testAdapter, scheme),
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testAdapter, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
 		},
 		ExpectStatusUpdates: []rtesting.Factory{
 			testAdapter.
@@ -313,6 +334,10 @@ func TestAdapterReconciler(t *testing.T) {
 			rtesting.NewTrackRequest(testContainer, testAdapter, scheme),
 			rtesting.NewTrackRequest(testService, testAdapter, scheme),
 		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testAdapter, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
 		ExpectUpdates: []rtesting.Factory{
 			testService.
 				UserContainer(func(uc *corev1.Container) {
@@ -353,6 +378,10 @@ func TestAdapterReconciler(t *testing.T) {
 		},
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testContainer, testAdapter, scheme),
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testAdapter, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
 		},
 		ExpectStatusUpdates: []rtesting.Factory{
 			testAdapter.
@@ -395,6 +424,10 @@ func TestAdapterReconciler(t *testing.T) {
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testContainer, testAdapter, scheme),
 			rtesting.NewTrackRequest(testService, testAdapter, scheme),
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testAdapter, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
 		},
 		ExpectStatusUpdates: []rtesting.Factory{
 			testAdapter.
@@ -492,6 +525,10 @@ func TestAdapterReconciler(t *testing.T) {
 			rtesting.NewTrackRequest(testContainer, testAdapter, scheme),
 			rtesting.NewTrackRequest(testConfiguration, testAdapter, scheme),
 		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testAdapter, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
 		ExpectUpdates: []rtesting.Factory{
 			testConfiguration.
 				UserContainer(func(uc *corev1.Container) {
@@ -521,6 +558,10 @@ func TestAdapterReconciler(t *testing.T) {
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testContainer, testAdapter, scheme),
 			rtesting.NewTrackRequest(testConfiguration, testAdapter, scheme),
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testAdapter, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
 		},
 		ExpectStatusUpdates: []rtesting.Factory{
 			testAdapter.
@@ -604,12 +645,13 @@ func TestAdapterReconciler(t *testing.T) {
 		},
 	}}
 
-	table.Test(t, scheme, func(t *testing.T, row *rtesting.Testcase, client client.Client, tracker tracker.Tracker, log logr.Logger) reconcile.Reconciler {
+	table.Test(t, scheme, func(t *testing.T, row *rtesting.Testcase, client client.Client, tracker tracker.Tracker, recorder record.EventRecorder, log logr.Logger) reconcile.Reconciler {
 		return &knative.AdapterReconciler{
-			Client:  client,
-			Log:     log,
-			Scheme:  scheme,
-			Tracker: tracker,
+			Client:   client,
+			Recorder: recorder,
+			Log:      log,
+			Scheme:   scheme,
+			Tracker:  tracker,
 		}
 	})
 }

--- a/pkg/controllers/knative/deployer_controller_test.go
+++ b/pkg/controllers/knative/deployer_controller_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -151,6 +152,14 @@ func TestDeployerReconciler(t *testing.T) {
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testApplication, testDeployer, scheme),
 		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "Created",
+				`Created Configuration "%s-deployer-001"`, testName),
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "Created",
+				`Created Route "%s"`, testName),
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
 		ExpectCreates: []rtesting.Factory{
 			testConfigurationCreate,
 			testRouteCreate,
@@ -175,6 +184,10 @@ func TestDeployerReconciler(t *testing.T) {
 		},
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testApplication, testDeployer, scheme),
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
 		},
 		ExpectStatusUpdates: []rtesting.Factory{
 			testDeployer.
@@ -222,6 +235,14 @@ func TestDeployerReconciler(t *testing.T) {
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testFunction, testDeployer, scheme),
 		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "Created",
+				`Created Configuration "%s-deployer-001"`, testName),
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "Created",
+				`Created Route "%s"`, testName),
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
 		ExpectCreates: []rtesting.Factory{
 			testConfigurationCreate,
 			testRouteCreate,
@@ -246,6 +267,10 @@ func TestDeployerReconciler(t *testing.T) {
 		},
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testFunction, testDeployer, scheme),
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
 		},
 		ExpectStatusUpdates: []rtesting.Factory{
 			testDeployer.
@@ -293,6 +318,14 @@ func TestDeployerReconciler(t *testing.T) {
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testContainer, testDeployer, scheme),
 		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "Created",
+				`Created Configuration "%s-deployer-001"`, testName),
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "Created",
+				`Created Route "%s"`, testName),
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
 		ExpectCreates: []rtesting.Factory{
 			testConfigurationCreate,
 			testRouteCreate,
@@ -317,6 +350,10 @@ func TestDeployerReconciler(t *testing.T) {
 		},
 		ExpectTracks: []rtesting.TrackRequest{
 			rtesting.NewTrackRequest(testContainer, testDeployer, scheme),
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
 		},
 		ExpectStatusUpdates: []rtesting.Factory{
 			testDeployer.
@@ -360,6 +397,14 @@ func TestDeployerReconciler(t *testing.T) {
 			testDeployer.
 				Image(testImage),
 		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "Created",
+				`Created Configuration "%s-deployer-001"`, testName),
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "Created",
+				`Created Route "%s"`, testName),
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
 		ExpectCreates: []rtesting.Factory{
 			testConfigurationCreate,
 			testRouteCreate,
@@ -386,6 +431,12 @@ func TestDeployerReconciler(t *testing.T) {
 				Image(testImage),
 		},
 		ShouldErr: true,
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeWarning, "CreationFailed",
+				`Failed to create Configuration "": inducing failure for create Configuration`),
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
 		ExpectCreates: []rtesting.Factory{
 			testConfigurationCreate,
 		},
@@ -409,6 +460,14 @@ func TestDeployerReconciler(t *testing.T) {
 				Image(testImage),
 		},
 		ShouldErr: true,
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "Created",
+				`Created Configuration "%s-deployer-001"`, testName),
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeWarning, "CreationFailed",
+				`Failed to create Route "%s": inducing failure for create Route`, testName),
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
 		ExpectCreates: []rtesting.Factory{
 			testConfigurationCreate,
 			testRouteCreate,
@@ -435,6 +494,14 @@ func TestDeployerReconciler(t *testing.T) {
 			testDeployer.
 				Image(testImage),
 		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "Created",
+				`Created Configuration "%s-deployer-001"`, testName),
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeWarning, "CreationFailed",
+				`Failed to create Route "%s":  "%s" already exists`, testName, testName),
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
 		ExpectCreates: []rtesting.Factory{
 			testConfigurationCreate,
 			testRouteCreate,
@@ -459,6 +526,18 @@ func TestDeployerReconciler(t *testing.T) {
 				NamespaceName(testNamespace, "extra-configuration-1"),
 			testConfigurationGiven.
 				NamespaceName(testNamespace, "extra-configuration-2"),
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "Deleted",
+				`Deleted Configuration "%s"`, "extra-configuration-1"),
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "Deleted",
+				`Deleted Configuration "%s"`, "extra-configuration-2"),
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "Created",
+				`Created Configuration "%s-deployer-001"`, testName),
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "Created",
+				`Created Route "%s"`, testName),
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
 		},
 		ExpectCreates: []rtesting.Factory{
 			testConfigurationCreate,
@@ -494,6 +573,12 @@ func TestDeployerReconciler(t *testing.T) {
 				NamespaceName(testNamespace, "extra-configuration-2"),
 		},
 		ShouldErr: true,
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeWarning, "DeleteFailed",
+				`Failed to delete Configuration "%s": inducing failure for delete Configuration`, "extra-configuration-1"),
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
 		ExpectDeletes: []rtesting.DeleteRef{
 			{Group: "serving.knative.dev", Kind: "Configuration", Namespace: testNamespace, Name: "extra-configuration-1"},
 		},
@@ -516,6 +601,18 @@ func TestDeployerReconciler(t *testing.T) {
 				NamespaceName(testNamespace, "extra-route-1"),
 			testRouteGiven.
 				NamespaceName(testNamespace, "extra-route-2"),
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "Created",
+				`Created Configuration "%s-deployer-001"`, testName),
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "Deleted",
+				`Deleted Route "%s"`, "extra-route-1"),
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "Deleted",
+				`Deleted Route "%s"`, "extra-route-2"),
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "Created",
+				`Created Route "%s"`, testName),
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
 		},
 		ExpectCreates: []rtesting.Factory{
 			testConfigurationCreate,
@@ -551,6 +648,14 @@ func TestDeployerReconciler(t *testing.T) {
 				NamespaceName(testNamespace, "extra-route-2"),
 		},
 		ShouldErr: true,
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "Created",
+				`Created Configuration "%s-deployer-001"`, testName),
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeWarning, "DeleteFailed",
+				`Failed to delete Route "%s": inducing failure for delete Route`, "extra-route-1"),
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
 		ExpectCreates: []rtesting.Factory{
 			testConfigurationCreate,
 		},
@@ -578,6 +683,12 @@ func TestDeployerReconciler(t *testing.T) {
 					container.Image = "bogus"
 				}),
 			testRouteGiven,
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "Updated",
+				`Updated Configuration "%s"`, testConfigurationGiven.Get().GetName()),
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
 		},
 		ExpectUpdates: []rtesting.Factory{
 			testConfigurationGiven,
@@ -609,6 +720,10 @@ func TestDeployerReconciler(t *testing.T) {
 			testRouteGiven,
 		},
 		ShouldErr: true,
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
 		ExpectStatusUpdates: []rtesting.Factory{
 			testDeployer.
 				StatusConditions(
@@ -634,6 +749,12 @@ func TestDeployerReconciler(t *testing.T) {
 			testRouteGiven,
 		},
 		ShouldErr: true,
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeWarning, "UpdateFailed",
+				`Failed to update Configuration "%s": inducing failure for update Configuration`, testConfigurationGiven.Get().GetName()),
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
 		ExpectUpdates: []rtesting.Factory{
 			testConfigurationGiven,
 		},
@@ -655,6 +776,12 @@ func TestDeployerReconciler(t *testing.T) {
 			testConfigurationGiven,
 			testRouteGiven.
 				Traffic(),
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "Updated",
+				`Updated Route "%s"`, testRouteGiven.Get().GetName()),
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
 		},
 		ExpectUpdates: []rtesting.Factory{
 			testRouteGiven,
@@ -684,6 +811,10 @@ func TestDeployerReconciler(t *testing.T) {
 				Traffic(),
 		},
 		ShouldErr: true,
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
 		ExpectStatusUpdates: []rtesting.Factory{
 			testDeployer.
 				StatusConditions(
@@ -708,6 +839,12 @@ func TestDeployerReconciler(t *testing.T) {
 				Traffic(),
 		},
 		ShouldErr: true,
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeWarning, "UpdateFailed",
+				`Failed to update Route "%s": inducing failure for update Route`, testRouteGiven.Get().GetName()),
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
 		ExpectUpdates: []rtesting.Factory{
 			testRouteGiven,
 		},
@@ -734,6 +871,10 @@ func TestDeployerReconciler(t *testing.T) {
 			testRouteGiven,
 		},
 		ShouldErr: true,
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeWarning, "StatusUpdateFailed",
+				`Failed to update status: inducing failure for update Deployer`),
+		},
 		ExpectStatusUpdates: []rtesting.Factory{
 			testDeployer.
 				StatusConditions(
@@ -761,6 +902,14 @@ func TestDeployerReconciler(t *testing.T) {
 				Image(testImage),
 			testConfigurationGiven,
 			testRouteGiven,
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "Updated",
+				`Updated Configuration "%s"`, testConfigurationGiven.Get().GetName()),
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "Updated",
+				`Updated Route "%s"`, testRouteGiven.Get().GetName()),
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
 		},
 		ExpectUpdates: []rtesting.Factory{
 			testConfigurationGiven.
@@ -798,6 +947,12 @@ func TestDeployerReconciler(t *testing.T) {
 				MaxScale(2),
 			testConfigurationGiven,
 			testRouteGiven,
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "Updated",
+				`Updated Configuration "%s"`, testConfigurationGiven.Get().GetName()),
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
 		},
 		ExpectUpdates: []rtesting.Factory{
 			testConfigurationGiven.
@@ -839,6 +994,10 @@ func TestDeployerReconciler(t *testing.T) {
 				StatusAddressURL(testAddressURL).
 				StatusURL(testURL),
 		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
 		ExpectStatusUpdates: []rtesting.Factory{
 			testDeployer.
 				StatusConditions(
@@ -866,6 +1025,10 @@ func TestDeployerReconciler(t *testing.T) {
 				StatusReady().
 				StatusAddressURL(testAddressURL).
 				StatusURL(testURL),
+		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
 		},
 		ExpectStatusUpdates: []rtesting.Factory{
 			testDeployer.
@@ -895,6 +1058,10 @@ func TestDeployerReconciler(t *testing.T) {
 				StatusAddressURL(testAddressURL).
 				StatusURL(testURL),
 		},
+		ExpectEvents: []rtesting.Event{
+			rtesting.NewEvent(testDeployer, scheme, corev1.EventTypeNormal, "StatusUpdated",
+				`Updated status`),
+		},
 		ExpectStatusUpdates: []rtesting.Factory{
 			testDeployer.
 				StatusConditions(
@@ -910,12 +1077,13 @@ func TestDeployerReconciler(t *testing.T) {
 		},
 	}}
 
-	table.Test(t, scheme, func(t *testing.T, row *rtesting.Testcase, client client.Client, tracker tracker.Tracker, log logr.Logger) reconcile.Reconciler {
+	table.Test(t, scheme, func(t *testing.T, row *rtesting.Testcase, client client.Client, tracker tracker.Tracker, recorder record.EventRecorder, log logr.Logger) reconcile.Reconciler {
 		return &knative.DeployerReconciler{
-			Client:  client,
-			Log:     log,
-			Scheme:  scheme,
-			Tracker: tracker,
+			Client:   client,
+			Recorder: recorder,
+			Log:      log,
+			Scheme:   scheme,
+			Tracker:  tracker,
 		}
 	})
 }

--- a/pkg/controllers/streaming/inmemoryprovider_controller.go
+++ b/pkg/controllers/streaming/inmemoryprovider_controller.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -48,6 +49,7 @@ const (
 // InMemoryProviderReconciler reconciles a InMemoryProvider object
 type InMemoryProviderReconciler struct {
 	client.Client
+	Recorder  record.EventRecorder
 	Log       logr.Logger
 	Scheme    *runtime.Scheme
 	Tracker   tracker.Tracker
@@ -59,6 +61,7 @@ type InMemoryProviderReconciler struct {
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;update;patch;delete
 
 func (r *InMemoryProviderReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()
@@ -86,8 +89,12 @@ func (r *InMemoryProviderReconciler) Reconcile(req ctrl.Request) (ctrl.Result, e
 		log.Info("updating inmemory provider status", "diff", cmp.Diff(originalInMemoryProvider.Status, inMemoryProvider.Status))
 		if updateErr := r.Status().Update(ctx, &inMemoryProvider); updateErr != nil {
 			log.Error(updateErr, "unable to update InMemoryProvider status", "inmemoryprovider", inMemoryProvider)
+			r.Recorder.Eventf(&inMemoryProvider, corev1.EventTypeWarning, "StatusUpdateFailed",
+				"Failed to update status: %v", updateErr)
 			return ctrl.Result{Requeue: true}, updateErr
 		}
+		r.Recorder.Eventf(&inMemoryProvider, corev1.EventTypeNormal, "StatusUpdated",
+			"Updated status")
 	}
 
 	return result, err
@@ -165,8 +172,12 @@ func (r *InMemoryProviderReconciler) reconcileGatewayDeployment(ctx context.Cont
 		for _, extraDeployment := range childDeployments.Items {
 			log.Info("deleting extra gateway deployment", "deployment", extraDeployment)
 			if err := r.Delete(ctx, &extraDeployment); err != nil {
+				r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeWarning, "DeleteFailed",
+					"Failed to delete gateway Deployment %q: %v", extraDeployment.Name, err)
 				return nil, err
 			}
+			r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeNormal, "Deleted",
+				"Deleted gateway Deployment %q", extraDeployment.Name)
 		}
 	}
 
@@ -184,8 +195,12 @@ func (r *InMemoryProviderReconciler) reconcileGatewayDeployment(ctx context.Cont
 	if desiredDeployment == nil {
 		if err := r.Delete(ctx, &actualDeployment); err != nil {
 			log.Error(err, "unable to delete Deployment for InMemoryProvider", "deployment", actualDeployment)
+			r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeWarning, "DeleteFailed",
+				"Failed to delete gateway Deployment %q: %v", actualDeployment.Name, err)
 			return nil, err
 		}
+		r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeNormal, "Deleted",
+			"Deleted gateway Deployment %q", actualDeployment.Name)
 		return nil, nil
 	}
 
@@ -194,8 +209,12 @@ func (r *InMemoryProviderReconciler) reconcileGatewayDeployment(ctx context.Cont
 		log.Info("creating gateway deployment", "spec", desiredDeployment.Spec)
 		if err := r.Create(ctx, desiredDeployment); err != nil {
 			log.Error(err, "unable to create Deployment for InMemoryProvider", "deployment", desiredDeployment)
+			r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeWarning, "CreationFailed",
+				"Failed to create gateway Deployment %q: %v", desiredDeployment.Name, err)
 			return nil, err
 		}
+		r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeNormal, "Created",
+			"Created gateway Deployment %q", desiredDeployment.Name)
 		return desiredDeployment, nil
 	}
 
@@ -215,8 +234,12 @@ func (r *InMemoryProviderReconciler) reconcileGatewayDeployment(ctx context.Cont
 	log.Info("reconciling gateway deployment", "diff", cmp.Diff(actualDeployment.Spec, deployment.Spec))
 	if err := r.Update(ctx, deployment); err != nil {
 		log.Error(err, "unable to update Deployment for InMemoryProvider", "deployment", deployment)
+		r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeWarning, "UpdateFailed",
+			"Failed to update gateway Deployment %q: %v", deployment.Name, err)
 		return nil, err
 	}
+	r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeNormal, "Updated",
+		"Updated gateway Deployment %q", deployment.Name)
 
 	return deployment, nil
 }
@@ -308,8 +331,12 @@ func (r *InMemoryProviderReconciler) reconcileGatewayService(ctx context.Context
 		for _, extraService := range childServices.Items {
 			log.Info("deleting extra gateway service", "service", extraService)
 			if err := r.Delete(ctx, &extraService); err != nil {
+				r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeWarning, "DeleteFailed",
+					"Failed to delete gateway Service %q: %v", extraService.Name, err)
 				return nil, err
 			}
+			r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeNormal, "Deleted",
+				"Deleted gateway Service %q", extraService.Name)
 		}
 	}
 
@@ -322,8 +349,12 @@ func (r *InMemoryProviderReconciler) reconcileGatewayService(ctx context.Context
 	if desiredService == nil {
 		if err := r.Delete(ctx, &actualService); err != nil {
 			log.Error(err, "unable to delete gateway Service for InMemoryProvider", "service", actualService)
+			r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeWarning, "DeleteFailed",
+				"Failed to delete gateway Service %q: %v", actualService.Name, err)
 			return nil, err
 		}
+		r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeNormal, "Deleted",
+			"Deleted gateway Service %q", actualService.Name)
 		return nil, nil
 	}
 
@@ -332,8 +363,12 @@ func (r *InMemoryProviderReconciler) reconcileGatewayService(ctx context.Context
 		log.Info("creating gateway service", "spec", desiredService.Spec)
 		if err := r.Create(ctx, desiredService); err != nil {
 			log.Error(err, "unable to create gateway Service for InMemoryProvider", "service", desiredService)
+			r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeWarning, "CreationFailed",
+				"Failed to create gateway Service %q: %v", desiredService.Name, err)
 			return nil, err
 		}
+		r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeNormal, "Created",
+			"Created gateway Service %q", desiredService.Name)
 		return desiredService, nil
 	}
 
@@ -352,8 +387,12 @@ func (r *InMemoryProviderReconciler) reconcileGatewayService(ctx context.Context
 	log.Info("reconciling gateway service", "diff", cmp.Diff(actualService.Spec, service.Spec))
 	if err := r.Update(ctx, service); err != nil {
 		log.Error(err, "unable to update gateway Service for InMemoryProvider", "service", service)
+		r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeWarning, "UpdateFailed",
+			"Failed to update gateway Service %q: %v", service.Name, err)
 		return nil, err
 	}
+	r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeNormal, "Updated",
+		"Updated gateway Service %q", service.Name)
 
 	return service, nil
 }
@@ -406,8 +445,12 @@ func (r *InMemoryProviderReconciler) reconcileProvisionerDeployment(ctx context.
 		for _, extraDeployment := range childDeployments.Items {
 			log.Info("deleting extra provisioner deployment", "deployment", extraDeployment)
 			if err := r.Delete(ctx, &extraDeployment); err != nil {
+				r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeWarning, "DeleteFailed",
+					"Failed to delete provisioner Deployment %q: %v", extraDeployment.Name, err)
 				return nil, err
 			}
+			r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeNormal, "Deleted",
+				"Deleted provisioner Deployment %q", extraDeployment.Name)
 		}
 	}
 
@@ -425,8 +468,12 @@ func (r *InMemoryProviderReconciler) reconcileProvisionerDeployment(ctx context.
 	if desiredDeployment == nil {
 		if err := r.Delete(ctx, &actualDeployment); err != nil {
 			log.Error(err, "unable to delete Deployment for InMemoryProvider", "deployment", actualDeployment)
+			r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeWarning, "DeleteFailed",
+				"Failed to delete provisioner Deployment %q: %v", actualDeployment.Name, err)
 			return nil, err
 		}
+		r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeNormal, "Deleted",
+			"Deleted provisioner Deployment %q", actualDeployment.Name)
 		return nil, nil
 	}
 
@@ -435,8 +482,12 @@ func (r *InMemoryProviderReconciler) reconcileProvisionerDeployment(ctx context.
 		log.Info("creating provisioner deployment", "spec", desiredDeployment.Spec)
 		if err := r.Create(ctx, desiredDeployment); err != nil {
 			log.Error(err, "unable to create Deployment for InMemoryProvider", "deployment", desiredDeployment)
+			r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeWarning, "CreationFailed",
+				"Failed to create provisioner Deployment %q: %v", desiredDeployment.Name, err)
 			return nil, err
 		}
+		r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeNormal, "Created",
+			"Created provisioner Deployment %q", desiredDeployment.Name)
 		return desiredDeployment, nil
 	}
 
@@ -456,8 +507,12 @@ func (r *InMemoryProviderReconciler) reconcileProvisionerDeployment(ctx context.
 	log.Info("reconciling provisioner deployment", "diff", cmp.Diff(actualDeployment.Spec, deployment.Spec))
 	if err := r.Update(ctx, deployment); err != nil {
 		log.Error(err, "unable to update Deployment for InMemoryProvider", "deployment", deployment)
+		r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeWarning, "UpdateFailed",
+			"Failed to update provisioner Deployment %q: %v", deployment.Name, err)
 		return nil, err
 	}
+	r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeNormal, "Updated",
+		"Updated provisioner Deployment %q", deployment.Name)
 
 	return deployment, nil
 }
@@ -522,8 +577,12 @@ func (r *InMemoryProviderReconciler) reconcileProvisionerService(ctx context.Con
 		for _, extraService := range childServices.Items {
 			log.Info("deleting extra provisioner service", "service", extraService)
 			if err := r.Delete(ctx, &extraService); err != nil {
+				r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeWarning, "DeleteFailed",
+					"Failed to delete provisioner Service %q: %v", extraService.Name, err)
 				return nil, err
 			}
+			r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeNormal, "Deleted",
+				"Deleted provisioner Service %q", extraService.Name)
 		}
 	}
 
@@ -536,8 +595,12 @@ func (r *InMemoryProviderReconciler) reconcileProvisionerService(ctx context.Con
 	if desiredService == nil {
 		if err := r.Delete(ctx, &actualService); err != nil {
 			log.Error(err, "unable to delete provisioner Service for InMemoryProvider", "service", actualService)
+			r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeWarning, "DeleteFailed",
+				"Failed to delete provisioner Serice %q: %v", actualService.Name, err)
 			return nil, err
 		}
+		r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeNormal, "Deleted",
+			"Deleted provisioner Service %q", actualService.Name)
 		return nil, nil
 	}
 
@@ -546,8 +609,12 @@ func (r *InMemoryProviderReconciler) reconcileProvisionerService(ctx context.Con
 		log.Info("creating provisioner service", "spec", desiredService.Spec)
 		if err := r.Create(ctx, desiredService); err != nil {
 			log.Error(err, "unable to create provisioner Service for InMemoryProvider", "service", desiredService)
+			r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeWarning, "CreationFailed",
+				"Failed to create provisioner Service %q: %v", desiredService.Name, err)
 			return nil, err
 		}
+		r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeNormal, "Created",
+			"Created provisioner Service %q", desiredService.Name)
 		return desiredService, nil
 	}
 
@@ -566,8 +633,12 @@ func (r *InMemoryProviderReconciler) reconcileProvisionerService(ctx context.Con
 	log.Info("reconciling provisioner service", "diff", cmp.Diff(actualService.Spec, service.Spec))
 	if err := r.Update(ctx, service); err != nil {
 		log.Error(err, "unable to update provisioner Service for InMemoryProvider", "service", service)
+		r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeWarning, "UpdateFailed",
+			"Failed to update provisioner Service %q: %v", service.Name, err)
 		return nil, err
 	}
+	r.Recorder.Eventf(inMemoryProvider, corev1.EventTypeNormal, "Updated",
+		"Updated provisioner Service %q", service.Name)
 
 	return service, nil
 }

--- a/pkg/controllers/testing/recorder.go
+++ b/pkg/controllers/testing/recorder.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2020 the original author or authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/projectriff/system/pkg/apis"
+)
+
+type Event struct {
+	metav1.TypeMeta
+	types.NamespacedName
+	Type    string
+	Reason  string
+	Message string
+}
+
+func NewEvent(factory Factory, scheme *runtime.Scheme, eventtype, reason, messageFormat string, a ...interface{}) Event {
+	obj := factory.Get()
+	gvks, _, _ := scheme.ObjectKinds(obj)
+	apiVersion, kind := gvks[0].ToAPIVersionAndKind()
+
+	return Event{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apiVersion,
+			Kind:       kind,
+		},
+		NamespacedName: types.NamespacedName{
+			Namespace: obj.GetNamespace(),
+			Name:      obj.GetName(),
+		},
+		Type:    eventtype,
+		Reason:  reason,
+		Message: fmt.Sprintf(messageFormat, a...),
+	}
+}
+
+type eventRecorder struct {
+	events []Event
+	scheme *runtime.Scheme
+}
+
+var (
+	_ record.EventRecorder = (*eventRecorder)(nil)
+)
+
+func (r *eventRecorder) Event(object runtime.Object, eventtype, reason, message string) {
+	o := object.(apis.Object)
+	gvks, _, _ := r.scheme.ObjectKinds(o)
+	apiVersion, kind := gvks[0].ToAPIVersionAndKind()
+	r.events = append(r.events, Event{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apiVersion,
+			Kind:       kind,
+		},
+		NamespacedName: types.NamespacedName{
+			Namespace: o.GetNamespace(),
+			Name:      o.GetName(),
+		},
+		Type:    eventtype,
+		Reason:  reason,
+		Message: message,
+	})
+}
+
+func (r *eventRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+	r.Event(object, eventtype, reason, fmt.Sprintf(messageFmt, args...))
+}
+
+func (r *eventRecorder) PastEventf(object runtime.Object, timestamp metav1.Time, eventtype, reason, messageFmt string, args ...interface{}) {
+	panic("not implemented")
+}
+
+func (r *eventRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	r.Eventf(object, eventtype, reason, messageFmt, args...)
+}


### PR DESCRIPTION
Record an event for each successful and failed create, update and delete
of a child resource. As well as status updated for the reconciled
resource.

Events are displayed at the bottom of `kubectl describe`